### PR TITLE
Adds styles for organisms-flow~content-boxes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6012,6 +6012,114 @@
                       <div class="sidebar__group sidebar__group--level-3">
                         
                         <p class="sidebar__item sidebar__item--heading" data-slug="organisms">
+                          <a href="#patterns.organisms.flow-content-boxes">flow-content-boxes</a>
+                        </p>
+                        
+                        
+                      
+                            <div>
+                            
+                              <p class="sidebar__item sidebar__item--sub-heading" data-slug="patterns.organisms.flow-content-boxes-mixin">
+                                <a href="#patterns.organisms.flow-content-boxes-mixin">mixin</a>
+                              </p>
+                              
+                              <ul class="list-unstyled">
+                              
+                                
+                                  <li class="sidebar__item sassdoc__item" data-group="patterns.organisms.flow-content-boxes" data-name="organisms-flow-content-boxes" data-type="mixin">
+                                    
+                                    <a href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
+                                      
+                                      organisms-flow-content-boxes
+                                      
+                                      
+                                      
+                                    </a>
+                                    
+                                  </li>
+                                
+                                
+                                  <li class="sidebar__item sassdoc__item" data-group="patterns.organisms.flow-content-boxes" data-name="organisms-flow-content-boxes--theme" data-type="mixin">
+                                    
+                                    <a href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
+                                      
+                                      organisms-flow-content-boxes--theme
+                                      
+                                      
+                                      
+                                    </a>
+                                    
+                                  </li>
+                                
+                                
+                              </ul>
+                            
+                            </div>
+                        
+                        
+                      
+                            <div>
+                            
+                              <p class="sidebar__item sidebar__item--sub-heading" data-slug="patterns.organisms.flow-content-boxes-variable">
+                                <a href="#patterns.organisms.flow-content-boxes-variable">variable</a>
+                              </p>
+                              
+                              <ul class="list-unstyled">
+                              
+                                
+                                  <li class="sidebar__item sassdoc__item" data-group="patterns.organisms.flow-content-boxes" data-name="organisms-flow-content-boxes" data-type="variable">
+                                    
+                                    <a href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
+                                      
+                                      organisms-flow-content-boxes
+                                      
+                                      
+                                      
+                                    </a>
+                                    
+                                  </li>
+                                
+                                
+                              </ul>
+                            
+                            </div>
+                        
+                        
+                      
+                            <div>
+                            
+                              <p class="sidebar__item sidebar__item--sub-heading" data-slug="patterns.organisms.flow-content-boxes-placeholder">
+                                <a href="#patterns.organisms.flow-content-boxes-placeholder">placeholder</a>
+                              </p>
+                              
+                              <ul class="list-unstyled">
+                              
+                                
+                                  <li class="sidebar__item sassdoc__item" data-group="patterns.organisms.flow-content-boxes" data-name="organisms-flow-content-boxes" data-type="placeholder">
+                                    
+                                    <a href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
+                                      
+                                      organisms-flow-content-boxes
+                                      
+                                      
+                                      
+                                    </a>
+                                    
+                                  </li>
+                                
+                                
+                              </ul>
+                            
+                            </div>
+                        
+                        
+                      </div>
+                  
+                  
+                
+                      <div class="sidebar__group sidebar__group--level-3">
+                        
+                        <p class="sidebar__item sidebar__item--heading" data-slug="organisms">
                           <a href="#patterns.organisms.intro">intro</a>
                         </p>
                         
@@ -45803,7 +45911,7 @@
                               
                               
                                 
-                                  <span class="item__status item__status--construction">construction</span>
+                                  <span class="item__status item__status--review">review</span>
                                 
                               </h3>
                               
@@ -48452,10 +48560,10 @@
                                   <pre class="item__code item__code--togglable language-scss"
                                       data-current-state="collapsed"
                                       data-expanded="%molecules-feature { 
-                                
+                              
                                 // Capture selector.
                                 $selector: &amp;;
-                                
+                              
                                 // Builds the feature structure.
                                 display: grid;
                                 grid-template-areas: &quot;image&quot;
@@ -48463,7 +48571,7 @@
                                                      &quot;heading&quot;
                                                      &quot;action&quot;;
                                 grid-template-rows: 250px repeat(3, min-content);
-                                
+                              
                                 // Modifies structure for larger screens.
                                 @include breakpoint-m-l {
                                   grid-template-areas: &quot;image context&quot;
@@ -48471,7 +48579,7 @@
                                                        &quot;image action&quot;;
                                   grid-template-rows: repeat(2, min-content) 1fr;
                                 };
-                                
+                              
                                 // Modifies styles for descriptions.
                                 &amp;.has-description {
                                   grid-template-areas: &quot;image&quot;
@@ -48479,7 +48587,7 @@
                                                        &quot;heading&quot;
                                                        &quot;description&quot;
                                                        &quot;action&quot;;
-                                  
+                              
                                   // Modifies styles for descriptions.
                                   @include breakpoint-m-l {
                                     grid-template-areas: &quot;image context&quot;
@@ -48488,37 +48596,38 @@
                                                          &quot;image action&quot;;
                                     grid-template-rows: repeat(2, min-content) auto 1fr;
                                   };
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature image structure.
                                 &amp;-image {
                                   @include absolute( 0 );
                                   @include absolute-center-contents;
                                   grid-area: image;
                                   overflow: hidden;
-                                  
+                              
                                   img {
                                     width: 100%;
-                                    
+                                    object-fit: cover;
+                              
                                     @include breakpoint-m-l {
                                       height: 100%;
                                       width: auto;
                                       min-width: 100%;
                                     };
-                                    
+                              
                                   }
-                                  
+                              
                                   &amp;::after {
                                     content: &#x27;&#x27;;
                                     display: block;
                                     @include absolute( 0 );
                                   }
-                                  
+                              
                                   @include breakpoint-m-l {
                                     align-items: center;
                                   };
-                                  
+                              
                                   // Modifies structure in terms of image alignment.
                                   &amp;.-align-x-left {
                                     justify-content: flex-start;
@@ -48538,39 +48647,39 @@
                                   &amp;.-align-y-center {
                                     align-items: center;
                                   }
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature context structure.
                                 &amp;-context {
                                   grid-area: context;
                                   margin: 0;
                                 }
-                                
+                              
                                 // Builds feature heading structure.
                                 &amp;-heading {
                                   grid-area: heading;
                                   margin: 0;
                                 }
-                                
+                              
                                 // Builds feature description structure.
                                 &amp;-description {
                                   grid-area: description;
                                   margin: 0;
                                   display: none;
-                                  
+                              
                                   // Requires a flag to show descriptions.
                                   @include when-descendant-of( &#x27;#{$selector}.has-description&#x27; ) {
                                     display: block;
                                   };
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature action structure.
                                 &amp;-action {
                                   grid-area: action;
                                 }
-                                
+                              
                                }"
                                       data-collapsed="%molecules-feature { ... }"><code class="js-autoindent">%molecules-feature { ... }</code></pre>
                               
@@ -58011,6 +58120,8 @@
             
             
             
+            
+            
             <section class="main__section main__section--level-2 ">
             
               <h2 class="main__heading" id="patterns.organisms">
@@ -58018,6 +58129,677 @@
                 <div class="container">Organisms</div>
                 
               </h2>
+              
+              
+              
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                  
+                  <section class="main__section main__section--level-3 main__section--has-content">
+                  
+                    <h3 class="main__heading" id="patterns.organisms.flow-content-boxes">
+                      
+                      <div class="container">flow-content-boxes</div>
+                      
+                    </h3>
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-mixin">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">mixins</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                  <span class="item__status item__status--construction">construction</span>
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                
+                              
+                                  
+                                    
+                              
+                                
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code  item__code--togglable language-scss"
+                                       data-current-state="collapsed"
+                                       data-expanded="@mixin organisms-flow-content-boxes($custom) { 
+                              
+                                // Extend the default skin.
+                                $skin: map-extend($organisms-flow-content-boxes, $custom);
+                              
+                                // Initialize the flow-content-boxes component.
+                                &amp; {
+                              
+                                  // Load structure.
+                                  @extend %organisms-flow-content-boxes;
+                              
+                              
+                                  // Load skins.
+                                  @include organisms-flow-content-boxes--theme( $skin );
+                              
+                                }
+                              
+                               }"
+                                       data-collapsed="@mixin organisms-flow-content-boxes($custom) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes($custom) { ... }</code></pre>
+                              
+                                  
+                                </div>
+                              
+                                
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Builds a constructor for the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                                  <h3 class="item__sub-heading">Parameters</h3>
+                                  
+                                  
+                                    <table class="item__parameters">
+                                      
+                                      <thead>
+                                        <tr>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Name
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Description
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Type
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Default value
+                                          </th>
+                                        </tr>
+                                      </thead>
+                                      
+                                      <tbody>
+                                          <tr class="item__parameter">
+                                            <th scope="row" data-label="name">
+                                              <code>$custom</code>
+                                            </th>
+                                            <td data-label="desc">
+                                              <p>A custom skin for the component</p>
+                                  
+                                            </td>
+                                            <td data-label="type">
+                                              <code>
+                                                  map
+                                              </code>
+                                            </td>
+                                            <td data-label="default">
+                                                &mdash;<span class="visually-hidden"> none</span>
+                                            </td>
+                                          </tr>
+                                      </tbody>
+                                      
+                                    </table>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Output</h3>
+                                    <div class="item__description"><p>The native structure and skin of our flow-content-boxes component</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">placeholder</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">variable</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme"><code>organisms-flow-content-boxes--theme</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                  
+                                          <li class="item__description item__description--inline">
+                                  
+                                            <span class="item__cross-type">external</span>
+                                  
+                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend"><code>Brandy::map-extend</code></a> 
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
+                                  organisms-flow-content-boxes--theme
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                
+                              
+                                  
+                                    
+                              
+                                
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code  item__code--togglable language-scss"
+                                       data-current-state="collapsed"
+                                       data-expanded="@mixin organisms-flow-content-boxes--theme($skin) { 
+                              
+                                // Capture themeable variables from skin.
+                                $gap: map-deep-get($skin, &#x27;gap&#x27;);
+                              
+                                // Defines the flow-content-boxes component&#x27;s base styles.
+                                grid-column-gap: $gap;
+                              
+                               }"
+                                       data-collapsed="@mixin organisms-flow-content-boxes--theme($skin) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes--theme($skin) { ... }</code></pre>
+                              
+                                  
+                                </div>
+                              
+                                
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the flow-content-boxes component theme.</p>
+                                  </div>
+                              
+                              
+                                  <h3 class="item__sub-heading">Parameters</h3>
+                                  
+                                  
+                                    <table class="item__parameters">
+                                      
+                                      <thead>
+                                        <tr>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Name
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Description
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Type
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Default value
+                                          </th>
+                                        </tr>
+                                      </thead>
+                                      
+                                      <tbody>
+                                          <tr class="item__parameter">
+                                            <th scope="row" data-label="name">
+                                              <code>$skin</code>
+                                            </th>
+                                            <td data-label="desc">
+                                              <p>The component&#39;s skin</p>
+                                  
+                                            </td>
+                                            <td data-label="type">
+                                              <code>
+                                                  map
+                                              </code>
+                                            </td>
+                                            <td data-label="default">
+                                                &mdash;<span class="visually-hidden"> none</span>
+                                            </td>
+                                          </tr>
+                                      </tbody>
+                                      
+                                    </table>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Output</h3>
+                                    <div class="item__description"><p>The flow-content-explorer component&#39;s themeable properties</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                  
+                                          <li class="item__description item__description--inline">
+                                  
+                                            <span class="item__cross-type">external</span>
+                                  
+                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get"><code>Brandy::map-deep-get</code></a> 
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-variable">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">variables</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code language-scss"><code class="js-autoindent">$organisms-flow-content-boxes: (
+                              
+                                &#x27;gap&#x27;: 36px,
+                              
+                              );</code></pre>
+                              
+                              
+                              
+                                </div>
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the base skin of the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Type</h3>
+                                  
+                                    <p>
+                                        <code>variable</code>
+                                    </p>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-placeholder">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">placeholders</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                <div class="item__code-wrapper">
+                              
+                                  <pre class="item__code item__code--togglable language-scss"
+                                      data-current-state="collapsed"
+                                      data-expanded="%organisms-flow-content-boxes { 
+                              
+                                // Captures the selector.
+                                $selector: &amp;;
+                              
+                                // Builds the flow-content-boxes structure.
+                                // ...
+                                display: grid;
+                                grid-template-columns: 1fr;
+                                grid-template-rows: minmax(460px, min-content);
+                              
+                                &amp;-feature{
+                                  grid-column: 1/span 1;
+                                }
+                              
+                                &amp;-explorer {
+                                  grid-column: 2/span 1;
+                                }
+                              
+                                @include breakpoint-xl() {
+                                  grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
+                                }
+                               }"
+                                      data-collapsed="%organisms-flow-content-boxes { ... }"><code class="js-autoindent">%organisms-flow-content-boxes { ... }</code></pre>
+                              
+                              
+                                </div>
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the base structure of the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                  
+                  </section>
+                  
+              
               
               
               
@@ -65785,7 +66567,7 @@
                               
                               
                                 
-                                  <span class="item__status item__status--construction">construction</span>
+                                  <span class="item__status item__status--review">review</span>
                                 
                               </h3>
                               
@@ -73699,6 +74481,8 @@
                             
                         
                         
+                            
+                            
                             
                             
                             

--- a/docs/index.html
+++ b/docs/index.html
@@ -58217,12 +58217,18 @@
                                   // Load structure.
                                   @extend %organisms-flow-content-boxes;
                               
-                              
                                   // Load skins.
                                   @include organisms-flow-content-boxes--theme( $skin );
                               
                                 }
                               
+                                &amp;-feature {
+                                  @extend %organisms-flow-content-boxes-feature;
+                                }
+                              
+                                &amp;-explorer {
+                                  @extend %organisms-flow-content-boxes-explorer;
+                                }
                                }"
                                        data-collapsed="@mixin organisms-flow-content-boxes($custom) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes($custom) { ... }</code></pre>
                               
@@ -58428,10 +58434,22 @@
                                        data-expanded="@mixin organisms-flow-content-boxes--theme($skin) { 
                               
                                 // Capture themeable variables from skin.
-                                $gap: map-deep-get($skin, &#x27;gap&#x27;);
+                                $gap-column: map-deep-get($skin, &#x27;gap-column&#x27;);
+                                $gap-row-mobile: map-deep-get($skin, &#x27;gap-row.mobile&#x27;);
+                                $gap-row-large: map-deep-get($skin, &#x27;gap-row.large&#x27;);
+                              
                               
                                 // Defines the flow-content-boxes component&#x27;s base styles.
-                                grid-column-gap: $gap;
+                                grid-row-gap: $gap-row-mobile;
+                              
+                                @include breakpoint-xl() {
+                                  grid-column-gap: $gap-column;
+                                  grid-row-gap: $gap-row-large;
+                                }
+                              
+                                &amp;-feature { }
+                              
+                                &amp;-explorer { }
                               
                                }"
                                        data-collapsed="@mixin organisms-flow-content-boxes--theme($skin) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes--theme($skin) { ... }</code></pre>
@@ -58514,6 +58532,20 @@
                                     <h3 class="item__sub-heading">Requires</h3>
                                   
                                     <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
+                                  
+                                  
+                                          </li>
+                                  
                                   
                                   
                                   
@@ -58601,7 +58633,11 @@
                                   
                                   <pre class="item__code language-scss"><code class="js-autoindent">$organisms-flow-content-boxes: (
                               
-                                &#x27;gap&#x27;: 36px,
+                                &#x27;gap-column&#x27;: 36px,
+                                &#x27;gap-row&#x27;: (
+                                  &#x27;mobile&#x27;: 23px,
+                                  &#x27;large&#x27;: 0,
+                                  )
                               
                               );</code></pre>
                               
@@ -58713,15 +58749,24 @@
                                 grid-template-rows: minmax(460px, min-content);
                               
                                 &amp;-feature{
-                                  grid-column: 1/span 1;
+                                  order: 2;
                                 }
                               
                                 &amp;-explorer {
-                                  grid-column: 2/span 1;
+                                  order: 1;
                                 }
                               
                                 @include breakpoint-xl() {
                                   grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
+                              
+                                  &amp;-feature{
+                                    grid-column: 1/span 1;
+                                  }
+                              
+                                  &amp;-explorer {
+                                    grid-column: 2/span 1;
+                                  }
+                              
                                 }
                                }"
                                       data-collapsed="%organisms-flow-content-boxes { ... }"><code class="js-autoindent">%organisms-flow-content-boxes { ... }</code></pre>
@@ -74481,6 +74526,8 @@
                             
                         
                         
+                            
+                            
                             
                             
                             

--- a/docs/index.html
+++ b/docs/index.html
@@ -48331,20 +48331,6 @@
                               
                                   <pre class="item__code item__code--togglable language-scss"
                                       data-current-state="collapsed"
-                                      data-expanded="%molecules-feature { 
-                              
-                                // Capture selector.
-                                $selector: &amp;;
-                              
-                                // Builds the feature structure.
-                                display: grid;
-                                grid-template-areas: &quot;image&quot;
-                                                     &quot;context&quot;
-                                                     &quot;heading&quot;
-                                                     &quot;action&quot;;
-                                grid-template-rows: 250px repeat(3, min-content);
-                              
-                                // Modifies structure for larger screens.
                                       data-expanded="%molecules-card-staff { 
                                 
                                 // Builds the card-staff structure.
@@ -48356,51 +48342,6 @@
                                   grid-template-areas: &quot;about contact&quot;;
                                   grid-template-columns: 2fr 1fr;
                                 };
-                              
-                                // Modifies styles for descriptions.
-                                &amp;.has-description {
-                                  grid-template-areas: &quot;image&quot;
-                                                       &quot;context&quot;
-                                                       &quot;heading&quot;
-                                                       &quot;description&quot;
-                                                       &quot;action&quot;;
-                              
-                                  // Modifies styles for descriptions.
-                                  @include breakpoint-m-l {
-                                    grid-template-areas: &quot;image context&quot;
-                                                         &quot;image heading&quot;
-                                                         &quot;image description&quot;
-                                                         &quot;image action&quot;;
-                                    grid-template-rows: repeat(2, min-content) auto 1fr;
-                                  };
-                              
-                                }
-                              
-                                // Builds feature image structure.
-                                &amp;-image {
-                                  @include absolute( 0 );
-                                  @include absolute-center-contents;
-                                  grid-area: image;
-                                  overflow: hidden;
-                              
-                                  img {
-                                    width: 100%;
-                                    object-fit: cover;
-                              
-                                    @include breakpoint-m-l {
-                                      height: 100%;
-                                      width: auto;
-                                      min-width: 100%;
-                                    };
-                              
-                                  }
-                              
-                                  &amp;::after {
-                                    content: &#x27;&#x27;;
-                                    display: block;
-                                    @include absolute( 0 );
-                                  }
-                            
                                 
                                 // Builds the card&#x27;s about and contact structure.
                                 &amp;-contact {
@@ -48468,31 +48409,9 @@
                                   }
                                   
                                   // Only shows contact on larger screens.
-
                                   @include breakpoint-m-l {
                                     display: flex;
                                   };
-
-                              
-                                  // Modifies structure in terms of image alignment.
-                                  &amp;.-align-x-left {
-                                    justify-content: flex-start;
-                                  }
-                                  &amp;.-align-x-center {
-                                    justify-content: center;
-                                  }
-                                  &amp;.-align-x-right {
-                                    justify-content: flex-end;
-                                  }
-                                  &amp;.-align-y-top {
-                                    align-items: top;
-                                  }
-                                  &amp;.-align-y-bottom {
-                                    align-items: bottom;
-                                  }
-                                  &amp;.-align-y-center {
-                                    align-items: center;
-
                                   
                                 }
                                 
@@ -48507,49 +48426,16 @@
                                   
                                   img {
                                     width: 100%;
-
                                   }
-                              
+                                  
                                 }
-
-                              
-                                // Builds feature context structure.
-                                &amp;-context {
-                                  grid-area: context;
-
                                 
                                 // Builds the card name structure.
                                 &amp;-name {
                                   grid-area: name;
-
                                   margin: 0;
                                   @include absolute-center-contents( true );
                                 }
-
-                              
-                                // Builds feature heading structure.
-                                &amp;-heading {
-                                  grid-area: heading;
-                                  margin: 0;
-                                }
-                              
-                                // Builds feature description structure.
-                                &amp;-description {
-                                  grid-area: description;
-                                  margin: 0;
-                                  display: none;
-                              
-                                  // Requires a flag to show descriptions.
-                                  @include when-descendant-of( &#x27;#{$selector}.has-description&#x27; ) {
-                                    display: block;
-                                  };
-                              
-                                }
-                              
-                                // Builds feature action structure.
-                                &amp;-action {
-                                  grid-area: action;
-
                                 
                                 // Builds the card title structure.
                                 &amp;-title { 
@@ -48567,9 +48453,8 @@
                                 &amp;-context {
                                   grid-area: context;
                                   margin: 0;
-
                                 }
-                              
+                                
                                }"
                                       data-collapsed="%molecules-card-staff { ... }"><code class="js-autoindent">%molecules-card-staff { ... }</code></pre>
                               
@@ -50282,10 +50167,10 @@
                                   <pre class="item__code item__code--togglable language-scss"
                                       data-current-state="collapsed"
                                       data-expanded="%molecules-feature { 
-                                
+                              
                                 // Capture selector.
                                 $selector: &amp;;
-                                
+                              
                                 // Builds the feature structure.
                                 display: grid;
                                 grid-template-areas: &quot;image&quot;
@@ -50293,7 +50178,7 @@
                                                      &quot;heading&quot;
                                                      &quot;action&quot;;
                                 grid-template-rows: 250px repeat(3, min-content);
-                                
+                              
                                 // Modifies structure for larger screens.
                                 @include breakpoint-m-l {
                                   grid-template-areas: &quot;image context&quot;
@@ -50301,7 +50186,7 @@
                                                        &quot;image action&quot;;
                                   grid-template-rows: repeat(2, min-content) 1fr;
                                 };
-                                
+                              
                                 // Modifies styles for descriptions.
                                 &amp;.has-description {
                                   grid-template-areas: &quot;image&quot;
@@ -50309,7 +50194,7 @@
                                                        &quot;heading&quot;
                                                        &quot;description&quot;
                                                        &quot;action&quot;;
-                                  
+                              
                                   // Modifies styles for descriptions.
                                   @include breakpoint-m-l {
                                     grid-template-areas: &quot;image context&quot;
@@ -50318,37 +50203,38 @@
                                                          &quot;image action&quot;;
                                     grid-template-rows: repeat(2, min-content) auto 1fr;
                                   };
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature image structure.
                                 &amp;-image {
                                   @include absolute( 0 );
                                   @include absolute-center-contents;
                                   grid-area: image;
                                   overflow: hidden;
-                                  
+                              
                                   img {
                                     width: 100%;
-                                    
+                                    object-fit: cover;
+                              
                                     @include breakpoint-m-l {
                                       height: 100%;
                                       width: auto;
                                       min-width: 100%;
                                     };
-                                    
+                              
                                   }
-                                  
+                              
                                   &amp;::after {
                                     content: &#x27;&#x27;;
                                     display: block;
                                     @include absolute( 0 );
                                   }
-                                  
+                              
                                   @include breakpoint-m-l {
                                     align-items: center;
                                   };
-                                  
+                              
                                   // Modifies structure in terms of image alignment.
                                   &amp;.-align-x-left {
                                     justify-content: flex-start;
@@ -50368,39 +50254,39 @@
                                   &amp;.-align-y-center {
                                     align-items: center;
                                   }
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature context structure.
                                 &amp;-context {
                                   grid-area: context;
                                   margin: 0;
                                 }
-                                
+                              
                                 // Builds feature heading structure.
                                 &amp;-heading {
                                   grid-area: heading;
                                   margin: 0;
                                 }
-                                
+                              
                                 // Builds feature description structure.
                                 &amp;-description {
                                   grid-area: description;
                                   margin: 0;
                                   display: none;
-                                  
+                              
                                   // Requires a flag to show descriptions.
                                   @include when-descendant-of( &#x27;#{$selector}.has-description&#x27; ) {
                                     display: block;
                                   };
-                                  
+                              
                                 }
-                                
+                              
                                 // Builds feature action structure.
                                 &amp;-action {
                                   grid-area: action;
                                 }
-                                
+                              
                                }"
                                       data-collapsed="%molecules-feature { ... }"><code class="js-autoindent">%molecules-feature { ... }</code></pre>
                               
@@ -57870,8 +57756,7 @@
                               
                               
                                     <h3 class="item__sub-heading">Output</h3>
-
-                                    <div class="item__description"><p>The native structure and skin of our wayfinder component</p>
+                                    <div class="item__description"><p>The native structure and skin of our tile-utility component</p>
                                   </div>
                               
                               
@@ -57890,7 +57775,7 @@
                                   
                                             <span class="item__cross-type">placeholder</span>
                                   
-                                            <a href="#patterns.molecules.wayfinder-placeholder-molecules-wayfinder"><code>molecules-wayfinder</code></a>
+                                            <a href="#patterns.molecules.tile-utility-placeholder-molecules-tile-utility"><code>molecules-tile-utility</code></a>
                                   
                                   
                                           </li>
@@ -57904,7 +57789,7 @@
                                   
                                             <span class="item__cross-type">variable</span>
                                   
-                                            <a href="#patterns.molecules.wayfinder-variable-molecules-wayfinder"><code>molecules-wayfinder</code></a>
+                                            <a href="#patterns.molecules.tile-utility-variable-molecules-tile-utility"><code>molecules-tile-utility</code></a>
                                   
                                   
                                           </li>
@@ -57918,7 +57803,7 @@
                                   
                                             <span class="item__cross-type">mixin</span>
                                   
-                                            <a href="#patterns.molecules.wayfinder-mixin-molecules-wayfinder--theme"><code>molecules-wayfinder--theme</code></a>
+                                            <a href="#patterns.molecules.tile-utility-mixin-molecules-tile-utility--theme"><code>molecules-tile-utility--theme</code></a>
                                   
                                   
                                           </li>
@@ -57972,7 +57857,7 @@
                     
                     
                     
-                        <section class="main__sub-section" id="patterns.molecules.wayfinder-placeholder">
+                        <section class="main__sub-section" id="patterns.molecules.tile-utility-placeholder">
                           
                           <h4 class="main__heading--secondary">
                             
@@ -57982,13 +57867,13 @@
                           
                           
                             <section class="main__item container item"
-                                     id="patterns.molecules.wayfinder-placeholder-molecules-wayfinder">
+                                     id="patterns.molecules.tile-utility-placeholder-molecules-tile-utility">
                             
                               <h3 class="item__heading">
                                 
                               
-                                <a class="item__name" href="#patterns.molecules.wayfinder-placeholder-molecules-wayfinder">
-                                  molecules-wayfinder
+                                <a class="item__name" href="#patterns.molecules.tile-utility-placeholder-molecules-tile-utility">
+                                  molecules-tile-utility
                                 </a>
                               
                               
@@ -58008,855 +57893,6 @@
                               
                                   <pre class="item__code item__code--togglable language-scss"
                                       data-current-state="collapsed"
-                                      data-expanded="%molecules-wayfinder { 
-                                
-                                // Builds the wayfinder structure.
-                                display: grid;
-                                grid-template-areas: &quot;heading&quot;
-                                                     &quot;text&quot;
-                                                     &quot;action&quot;;
-                                grid-template-rows: min-content 1fr min-content;
-                                grid-template-columns: 1fr;
-                                
-                                &amp;::before,
-                                &amp;::after {
-                                  content: &#x27;&#x27;;
-                                  display: block;
-                                  @include absolute( 0 );
-                                  z-index: 1;
-                                }
-                                
-                                // Builds the wayfinder image structure.
-                                &amp;-image { 
-                                  @include absolute-center-contents;
-                                  overflow: hidden;
-                                  position: absolute;
-                                  top: 0;
-                                  left: 0;
-                                  right: 0;
-                                  z-index: 0;
-                                  
-                                  img {
-                                    width: 100%;
-                                    height: auto;
-                                    min-height: 100%;
-                                  }
-                                  
-                                  // Modifies structure on larger screens.
-                                  @include breakpoint-m-l {
-                                    bottom: 0;
-                                    right: auto;
-                                  };
-                                  
-                                  // Applies image variations.
-                                  &amp;.-align-x-left {
-                                    justify-content: flex-start;
-                                  }
-                                  &amp;.-align-x-right {
-                                    justify-content: flex-end;
-                                  }
-                                  &amp;.-align-x-center {
-                                    justify-content: center;
-                                  }
-                                  &amp;.-align-y-top {
-                                    align-items: flex-start;
-                                  }
-                                  &amp;.-align-y-bottom {
-                                    align-items: flex-end;
-                                  }
-                                  &amp;.-align-y-center {
-                                    align-items: center;
-                                  }
-                                  
-                                }
-                                
-                                // Builds the wayfinder heading, text, and action structure.
-                                &amp;-heading,
-                                &amp;-text,
-                                &amp;-action {
-                                  z-index: 2;
-                                }
-                                
-                                // Builds the wayfinder heading and text structure.
-                                &amp;-heading,
-                                &amp;-text {
-                                  margin: 0;
-                                }
-                                
-                                // Builds the wayfinder heading structure.
-                                &amp;-heading { }
-                                
-                                // Builds the wayfinder text structure.
-                                &amp;-text { }
-                                
-                                // Builds the wayfinder action structure.
-                                &amp;-action { 
-                                  display: flex;
-                                  flex-wrap: nowrap;
-                                  flex-direction: column;
-                                  justify-content: center;
-                                  
-                                  // Modifies structure on larger screens.
-                                  @include breakpoint-m-l {
-                                    flex-direction: row;
-                                    flex-wrap: wrap;
-                                    justify-content: flex-start;
-                                  };
-                                  
-                                }
-                                
-                               }"
-                                      data-collapsed="%molecules-wayfinder { ... }"><code class="js-autoindent">%molecules-wayfinder { ... }</code></pre>
-                              
-                              
-                                </div>
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Description</h3>
-                                    <div class="item__description"><p>Defines the base structure of the wayfinder component.</p>
-                                  </div>
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                            
-                            </section>  
-                          
-                        </section>  
-                    
-                  
-                  </section>
-                  
-              
-              
-            
-            </section>
-            
-        
-        
-        
-        
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            <section class="main__section main__section--level-2 ">
-            
-              <h2 class="main__heading" id="patterns.organisms">
-                
-                <div class="container">Organisms</div>
-                
-              </h2>
-              
-              
-              
-                  
-                  
-                  
-                  
-                      
-                  
-                  
-                  
-                  
-                      
-                  
-                  
-                  
-                  
-                      
-                  
-                  
-                  
-                  
-                  
-                  <section class="main__section main__section--level-3 main__section--has-content">
-                  
-                    <h3 class="main__heading" id="patterns.organisms.flow-content-boxes">
-                      
-                      <div class="container">flow-content-boxes</div>
-                      
-                    </h3>
-                    
-                    
-                    
-                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-mixin">
-                          
-                          <h4 class="main__heading--secondary">
-                            
-                            <div class="container">mixins</div>
-                            
-                          </h4>
-                          
-                          
-                            <section class="main__item container item"
-                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
-                            
-                              <h3 class="item__heading">
-                                
-                              
-                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
-                                  organisms-flow-content-boxes
-                                </a>
-                              
-                              
-                                
-                                  <span class="item__status item__status--construction">construction</span>
-                                
-                              </h3>
-                              
-                              
-                                <span class="item__since">
-                                  Since 1.0.0-dev.0
-                                </span>
-                              
-                              
-                            
-                              
-                                
-                              
-                                  
-                                    
-                              
-                                
-                              
-                                <div class="item__code-wrapper">
-                                  
-                                  <pre class="item__code  item__code--togglable language-scss"
-                                       data-current-state="collapsed"
-                                       data-expanded="@mixin organisms-flow-content-boxes($custom) { 
-                              
-                                // Extend the default skin.
-                                $skin: map-extend($organisms-flow-content-boxes, $custom);
-                              
-                                // Initialize the flow-content-boxes component.
-                                &amp; {
-                              
-                                  // Load structure.
-                                  @extend %organisms-flow-content-boxes;
-                              
-                                  // Load skins.
-                                  @include organisms-flow-content-boxes--theme( $skin );
-                              
-                                }
-                              
-                                &amp;-feature {
-                                  @extend %organisms-flow-content-boxes-feature;
-                                }
-                              
-                                &amp;-explorer {
-                                  @extend %organisms-flow-content-boxes-explorer;
-                                }
-                               }"
-                                       data-collapsed="@mixin organisms-flow-content-boxes($custom) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes($custom) { ... }</code></pre>
-                              
-                                  
-                                </div>
-                              
-                                
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Description</h3>
-                                    <div class="item__description"><p>Builds a constructor for the flow-content-boxes component.</p>
-                                  </div>
-                              
-                              
-                                  <h3 class="item__sub-heading">Parameters</h3>
-                                  
-                                  
-                                    <table class="item__parameters">
-                                      
-                                      <thead>
-                                        <tr>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Name
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Description
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Type
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Default value
-                                          </th>
-                                        </tr>
-                                      </thead>
-                                      
-                                      <tbody>
-                                          <tr class="item__parameter">
-                                            <th scope="row" data-label="name">
-                                              <code>$custom</code>
-                                            </th>
-                                            <td data-label="desc">
-                                              <p>A custom skin for the component</p>
-                                  
-                                            </td>
-                                            <td data-label="type">
-                                              <code>
-                                                  map
-                                              </code>
-                                            </td>
-                                            <td data-label="default">
-                                                &mdash;<span class="visually-hidden"> none</span>
-                                            </td>
-                                          </tr>
-                                      </tbody>
-                                      
-                                    </table>
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Output</h3>
-                                    <div class="item__description"><p>The native structure and skin of our flow-content-boxes component</p>
-                                  </div>
-                              
-                              
-                              
-                              
-                                  
-                                    <h3 class="item__sub-heading">Requires</h3>
-                                  
-                                    <ul class="list-unstyled">
-                                  
-                                  
-                                    
-                                          
-                                  
-                                          <li class="item__description  item__description--inline">
-                                  
-                                            <span class="item__cross-type">placeholder</span>
-                                  
-                                            <a href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                    
-                                          
-                                  
-                                          <li class="item__description  item__description--inline">
-                                  
-                                            <span class="item__cross-type">variable</span>
-                                  
-                                            <a href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                    
-                                          
-                                  
-                                          <li class="item__description  item__description--inline">
-                                  
-                                            <span class="item__cross-type">mixin</span>
-                                  
-                                            <a href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme"><code>organisms-flow-content-boxes--theme</code></a>
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                  
-                                          <li class="item__description item__description--inline">
-                                  
-                                            <span class="item__cross-type">external</span>
-                                  
-                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend"><code>Brandy::map-extend</code></a> 
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                    </ul>
-                                  
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                            
-                            </section>  
-                          
-                            <section class="main__item container item"
-                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
-                            
-                              <h3 class="item__heading">
-                                
-                              
-                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
-                                  organisms-flow-content-boxes--theme
-                                </a>
-                              
-                              
-                                
-                                
-                              </h3>
-                              
-                              
-                                <span class="item__since">
-                                  Since 1.0.0-dev.0
-                                </span>
-                              
-                              
-                            
-                              
-                                
-                              
-                                  
-                                    
-                              
-                                
-                              
-                                <div class="item__code-wrapper">
-                                  
-                                  <pre class="item__code  item__code--togglable language-scss"
-                                       data-current-state="collapsed"
-                                       data-expanded="@mixin organisms-flow-content-boxes--theme($skin) { 
-                              
-                                // Capture themeable variables from skin.
-                                $gap-column: map-deep-get($skin, &#x27;gap-column&#x27;);
-                                $gap-row-s: map-deep-get($skin, &#x27;gap-row.s&#x27;);
-                                $gap-row-xl: map-deep-get($skin, &#x27;gap-row.xl&#x27;);
-                              
-                              
-                                // Defines the flow-content-boxes component&#x27;s base styles.
-                                grid-row-gap: $gap-row-s;
-                              
-                                @include breakpoint-xl() {
-                                  grid-column-gap: $gap-column;
-                                  grid-row-gap: $gap-row-xl;
-                                }
-                              
-                                &amp;-feature { }
-                              
-                                &amp;-explorer { }
-                              
-                               }"
-                                       data-collapsed="@mixin organisms-flow-content-boxes--theme($skin) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes--theme($skin) { ... }</code></pre>
-                              
-                                  
-                                </div>
-                              
-                                
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Description</h3>
-                                    <div class="item__description"><p>Defines the flow-content-boxes component theme.</p>
-                                  </div>
-                              
-                              
-                                  <h3 class="item__sub-heading">Parameters</h3>
-                                  
-                                  
-                                    <table class="item__parameters">
-                                      
-                                      <thead>
-                                        <tr>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Name
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Description
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Type
-                                          </th>
-                                          <th scope="col">
-                                            <span class="visually-hidden">mixin parameter </span>
-                                            Default value
-                                          </th>
-                                        </tr>
-                                      </thead>
-                                      
-                                      <tbody>
-                                          <tr class="item__parameter">
-                                            <th scope="row" data-label="name">
-                                              <code>$skin</code>
-                                            </th>
-                                            <td data-label="desc">
-                                              <p>The component&#39;s skin</p>
-                                  
-                                            </td>
-                                            <td data-label="type">
-                                              <code>
-                                                  map
-                                              </code>
-                                            </td>
-                                            <td data-label="default">
-                                                &mdash;<span class="visually-hidden"> none</span>
-                                            </td>
-                                          </tr>
-                                      </tbody>
-                                      
-                                    </table>
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Output</h3>
-                                    <div class="item__description"><p>The flow-content-explorer component&#39;s themeable properties</p>
-
-                                    <div class="item__description"><p>The native structure and skin of our tile-utility component</p>
-
-                                  </div>
-                              
-                              
-                              
-                              
-                                  
-                                    <h3 class="item__sub-heading">Requires</h3>
-                                  
-                                    <ul class="list-unstyled">
-                                  
-                                  
-                                    
-                                          
-                                  
-                                          <li class="item__description  item__description--inline">
-                                  
-                                            <span class="item__cross-type">mixin</span>
-                                  
-
-                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
-
-                                            <a href="#patterns.molecules.tile-utility-placeholder-molecules-tile-utility"><code>molecules-tile-utility</code></a>
-
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                  
-                                          <li class="item__description item__description--inline">
-                                  
-                                            <span class="item__cross-type">external</span>
-                                  
-
-                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get"><code>Brandy::map-deep-get</code></a> 
-
-                                            <a href="#patterns.molecules.tile-utility-variable-molecules-tile-utility"><code>molecules-tile-utility</code></a>
-
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                    </ul>
-                                  
-                              
-                              
-                                  
-                                  
-
-
-                                            <a href="#patterns.molecules.tile-utility-mixin-molecules-tile-utility--theme"><code>molecules-tile-utility--theme</code></a>
-
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                            
-                            </section>  
-                          
-                        </section>  
-                    
-                    
-                    
-                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-variable">
-                          
-                          <h4 class="main__heading--secondary">
-                            
-                            <div class="container">variables</div>
-                            
-                          </h4>
-                          
-                          
-                            <section class="main__item container item"
-                                     id="patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
-                            
-                              <h3 class="item__heading">
-                                
-                              
-                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
-                                  organisms-flow-content-boxes
-                                </a>
-                              
-                              
-                                
-                                
-                              </h3>
-                              
-                              
-                                <span class="item__since">
-                                  Since 1.0.0-dev.0
-                                </span>
-                              
-                              
-                            
-                              
-                                <div class="item__code-wrapper">
-                                  
-                                  <pre class="item__code language-scss"><code class="js-autoindent">$organisms-flow-content-boxes: (
-                              
-                                &#x27;gap-column&#x27;: 36px,
-                                &#x27;gap-row&#x27;: (
-                                  &#x27;s&#x27;: 23px,
-                                  &#x27;xl&#x27;: 0,
-                                )
-                              
-                              );</code></pre>
-                              
-                              
-                              
-                                </div>
-                              
-                              
-                              
-                              
-                                    <h3 class="item__sub-heading">Description</h3>
-                                    <div class="item__description"><p>Defines the base skin of the flow-content-boxes component.</p>
-                                  </div>
-                              
-                              
-                                  
-                                    <h3 class="item__sub-heading">Type</h3>
-                                  
-                                    <p>
-                                        <code>variable</code>
-                                    </p>
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                                  
-                                  
-                                  
-                                  
-                                  
-                                  
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                              
-                            
-                            </section>  
-                          
-                        </section>  
-                    
-                    
-                    
-
-                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-placeholder">
-
-                        <section class="main__sub-section" id="patterns.molecules.tile-utility-placeholder">
-
-                          
-                          <h4 class="main__heading--secondary">
-                            
-                            <div class="container">placeholders</div>
-                            
-                          </h4>
-                          
-                          
-                            <section class="main__item container item"
-
-                                     id="patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
-
-                                     id="patterns.molecules.tile-utility-placeholder-molecules-tile-utility">
-
-                            
-                              <h3 class="item__heading">
-                                
-                              
-
-                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
-                                  organisms-flow-content-boxes
-
-                                <a class="item__name" href="#patterns.molecules.tile-utility-placeholder-molecules-tile-utility">
-                                  molecules-tile-utility
-
-                                </a>
-                              
-                              
-                                
-                                
-                              </h3>
-                              
-                              
-                                <span class="item__since">
-                                  Since 1.0.0-dev.0
-                                </span>
-                              
-                              
-                            
-                              
-                                <div class="item__code-wrapper">
-                              
-                                  <pre class="item__code item__code--togglable language-scss"
-                                      data-current-state="collapsed"
-
-                                      data-expanded="%organisms-flow-content-boxes { 
-                              
-                                // Captures the selector.
-                                $selector: &amp;;
-                              
-                                // Builds the flow-content-boxes structure.
-                                // ...
-                                display: grid;
-                                grid-template-columns: 1fr;
-                                grid-template-rows: minmax(460px, min-content);
-                              
-                                &amp;-feature {
-                                  order: 2;
-                                  
-                                  @include breakpoint-xl {
-                                    order: unset;
-                                  };
-                                  
-                                }
-                              
-                                &amp;-explorer {
-                                  order: 1;
-                                  
-                                  @include breakpoint-xl {
-                                    order: unset;
-                                  };
-                                  
-
                                       data-expanded="%molecules-tile-utility { 
                                 
                                 // Capture selector.
@@ -58968,27 +58004,10 @@
                                 &amp;-description {
                                   grid-area: description;
                                   margin: 0;
-
                                 }
-                              
-                                @include breakpoint-xl() {
-                                  grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
-                              
-                                  &amp;-feature{
-                                    grid-column: 1;
-                                  }
-                              
-                                  &amp;-explorer {
-                                    grid-column: 2;
-                                  }
-                              
-                                }
+                                
                                }"
-
-                                      data-collapsed="%organisms-flow-content-boxes { ... }"><code class="js-autoindent">%organisms-flow-content-boxes { ... }</code></pre>
-
                                       data-collapsed="%molecules-tile-utility { ... }"><code class="js-autoindent">%molecules-tile-utility { ... }</code></pre>
-
                               
                               
                                 </div>
@@ -58997,11 +58016,7 @@
                               
                               
                                     <h3 class="item__sub-heading">Description</h3>
-
-                                    <div class="item__description"><p>Defines the base structure of the flow-content-boxes component.</p>
-
                                     <div class="item__description"><p>Defines the base structure of the tile-utility component.</p>
-
                                   </div>
                               
                               
@@ -59009,28 +58024,6 @@
                               
                               
                               
-                                  
-                                    <h3 class="item__sub-heading">Requires</h3>
-                                  
-                                    <ul class="list-unstyled">
-                                  
-                                  
-                                    
-                                          
-                                  
-                                          <li class="item__description  item__description--inline">
-                                  
-                                            <span class="item__cross-type">mixin</span>
-                                  
-                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
-                                  
-                                  
-                                          </li>
-                                  
-                                  
-                                  
-                                    </ul>
-                                  
                               
                               
                                   
@@ -60734,6 +59727,8 @@
             
             
             
+            
+            
             <section class="main__section main__section--level-2 ">
             
               <h2 class="main__heading" id="patterns.organisms">
@@ -60741,6 +59736,732 @@
                 <div class="container">Organisms</div>
                 
               </h2>
+              
+              
+              
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                      
+                  
+                  
+                  
+                  
+                  
+                  <section class="main__section main__section--level-3 main__section--has-content">
+                  
+                    <h3 class="main__heading" id="patterns.organisms.flow-content-boxes">
+                      
+                      <div class="container">flow-content-boxes</div>
+                      
+                    </h3>
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-mixin">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">mixins</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                  <span class="item__status item__status--construction">construction</span>
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                
+                              
+                                  
+                                    
+                              
+                                
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code  item__code--togglable language-scss"
+                                       data-current-state="collapsed"
+                                       data-expanded="@mixin organisms-flow-content-boxes($custom) { 
+                              
+                                // Extend the default skin.
+                                $skin: map-extend($organisms-flow-content-boxes, $custom);
+                              
+                                // Initialize the flow-content-boxes component.
+                                &amp; {
+                              
+                                  // Load structure.
+                                  @extend %organisms-flow-content-boxes;
+                              
+                                  // Load skins.
+                                  @include organisms-flow-content-boxes--theme( $skin );
+                              
+                                }
+                              
+                                &amp;-feature {
+                                  @extend %organisms-flow-content-boxes-feature;
+                                }
+                              
+                                &amp;-explorer {
+                                  @extend %organisms-flow-content-boxes-explorer;
+                                }
+                               }"
+                                       data-collapsed="@mixin organisms-flow-content-boxes($custom) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes($custom) { ... }</code></pre>
+                              
+                                  
+                                </div>
+                              
+                                
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Builds a constructor for the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                                  <h3 class="item__sub-heading">Parameters</h3>
+                                  
+                                  
+                                    <table class="item__parameters">
+                                      
+                                      <thead>
+                                        <tr>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Name
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Description
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Type
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Default value
+                                          </th>
+                                        </tr>
+                                      </thead>
+                                      
+                                      <tbody>
+                                          <tr class="item__parameter">
+                                            <th scope="row" data-label="name">
+                                              <code>$custom</code>
+                                            </th>
+                                            <td data-label="desc">
+                                              <p>A custom skin for the component</p>
+                                  
+                                            </td>
+                                            <td data-label="type">
+                                              <code>
+                                                  map
+                                              </code>
+                                            </td>
+                                            <td data-label="default">
+                                                &mdash;<span class="visually-hidden"> none</span>
+                                            </td>
+                                          </tr>
+                                      </tbody>
+                                      
+                                    </table>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Output</h3>
+                                    <div class="item__description"><p>The native structure and skin of our flow-content-boxes component</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">placeholder</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">variable</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes"><code>organisms-flow-content-boxes</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme"><code>organisms-flow-content-boxes--theme</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                  
+                                          <li class="item__description item__description--inline">
+                                  
+                                            <span class="item__cross-type">external</span>
+                                  
+                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend"><code>Brandy::map-extend</code></a> 
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-mixin-organisms-flow-content-boxes--theme">
+                                  organisms-flow-content-boxes--theme
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                
+                              
+                                  
+                                    
+                              
+                                
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code  item__code--togglable language-scss"
+                                       data-current-state="collapsed"
+                                       data-expanded="@mixin organisms-flow-content-boxes--theme($skin) { 
+                              
+                                // Capture themeable variables from skin.
+                                $gap-column: map-deep-get($skin, &#x27;gap-column&#x27;);
+                                $gap-row-s: map-deep-get($skin, &#x27;gap-row.s&#x27;);
+                                $gap-row-xl: map-deep-get($skin, &#x27;gap-row.xl&#x27;);
+                              
+                              
+                                // Defines the flow-content-boxes component&#x27;s base styles.
+                                grid-row-gap: $gap-row-s;
+                              
+                                @include breakpoint-xl() {
+                                  grid-column-gap: $gap-column;
+                                  grid-row-gap: $gap-row-xl;
+                                }
+                              
+                                &amp;-feature { }
+                              
+                                &amp;-explorer { }
+                              
+                               }"
+                                       data-collapsed="@mixin organisms-flow-content-boxes--theme($skin) { ... }"><code class="js-autoindent">@mixin organisms-flow-content-boxes--theme($skin) { ... }</code></pre>
+                              
+                                  
+                                </div>
+                              
+                                
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the flow-content-boxes component theme.</p>
+                                  </div>
+                              
+                              
+                                  <h3 class="item__sub-heading">Parameters</h3>
+                                  
+                                  
+                                    <table class="item__parameters">
+                                      
+                                      <thead>
+                                        <tr>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Name
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Description
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Type
+                                          </th>
+                                          <th scope="col">
+                                            <span class="visually-hidden">mixin parameter </span>
+                                            Default value
+                                          </th>
+                                        </tr>
+                                      </thead>
+                                      
+                                      <tbody>
+                                          <tr class="item__parameter">
+                                            <th scope="row" data-label="name">
+                                              <code>$skin</code>
+                                            </th>
+                                            <td data-label="desc">
+                                              <p>The component&#39;s skin</p>
+                                  
+                                            </td>
+                                            <td data-label="type">
+                                              <code>
+                                                  map
+                                              </code>
+                                            </td>
+                                            <td data-label="default">
+                                                &mdash;<span class="visually-hidden"> none</span>
+                                            </td>
+                                          </tr>
+                                      </tbody>
+                                      
+                                    </table>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Output</h3>
+                                    <div class="item__description"><p>The flow-content-explorer component&#39;s themeable properties</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                  
+                                          <li class="item__description item__description--inline">
+                                  
+                                            <span class="item__cross-type">external</span>
+                                  
+                                              <a href="https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get"><code>Brandy::map-deep-get</code></a> 
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-variable">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">variables</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-variable-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                <div class="item__code-wrapper">
+                                  
+                                  <pre class="item__code language-scss"><code class="js-autoindent">$organisms-flow-content-boxes: (
+                              
+                                &#x27;gap-column&#x27;: 36px,
+                                &#x27;gap-row&#x27;: (
+                                  &#x27;s&#x27;: 23px,
+                                  &#x27;xl&#x27;: 0,
+                                )
+                              
+                              );</code></pre>
+                              
+                              
+                              
+                                </div>
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the base skin of the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Type</h3>
+                                  
+                                    <p>
+                                        <code>variable</code>
+                                    </p>
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                    
+                    
+                        <section class="main__sub-section" id="patterns.organisms.flow-content-boxes-placeholder">
+                          
+                          <h4 class="main__heading--secondary">
+                            
+                            <div class="container">placeholders</div>
+                            
+                          </h4>
+                          
+                          
+                            <section class="main__item container item"
+                                     id="patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
+                            
+                              <h3 class="item__heading">
+                                
+                              
+                                <a class="item__name" href="#patterns.organisms.flow-content-boxes-placeholder-organisms-flow-content-boxes">
+                                  organisms-flow-content-boxes
+                                </a>
+                              
+                              
+                                
+                                
+                              </h3>
+                              
+                              
+                                <span class="item__since">
+                                  Since 1.0.0-dev.0
+                                </span>
+                              
+                              
+                            
+                              
+                                <div class="item__code-wrapper">
+                              
+                                  <pre class="item__code item__code--togglable language-scss"
+                                      data-current-state="collapsed"
+                                      data-expanded="%organisms-flow-content-boxes { 
+                              
+                                // Captures the selector.
+                                $selector: &amp;;
+                              
+                                // Builds the flow-content-boxes structure.
+                                // ...
+                                display: grid;
+                                grid-template-columns: 1fr;
+                                grid-template-rows: minmax(460px, min-content);
+                              
+                                &amp;-feature {
+                                  order: 2;
+                                  
+                                  @include breakpoint-xl {
+                                    order: unset;
+                                  };
+                                  
+                                }
+                              
+                                &amp;-explorer {
+                                  order: 1;
+                                  
+                                  @include breakpoint-xl {
+                                    order: unset;
+                                  };
+                                  
+                                }
+                              
+                                @include breakpoint-xl() {
+                                  grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
+                              
+                                  &amp;-feature{
+                                    grid-column: 1;
+                                  }
+                              
+                                  &amp;-explorer {
+                                    grid-column: 2;
+                                  }
+                              
+                                }
+                               }"
+                                      data-collapsed="%organisms-flow-content-boxes { ... }"><code class="js-autoindent">%organisms-flow-content-boxes { ... }</code></pre>
+                              
+                              
+                                </div>
+                              
+                              
+                              
+                              
+                                    <h3 class="item__sub-heading">Description</h3>
+                                    <div class="item__description"><p>Defines the base structure of the flow-content-boxes component.</p>
+                                  </div>
+                              
+                              
+                              
+                              
+                              
+                              
+                                  
+                                    <h3 class="item__sub-heading">Requires</h3>
+                                  
+                                    <ul class="list-unstyled">
+                                  
+                                  
+                                    
+                                          
+                                  
+                                          <li class="item__description  item__description--inline">
+                                  
+                                            <span class="item__cross-type">mixin</span>
+                                  
+                                            <a href="#utils.mixins-mixin-breakpoint-xl"><code>breakpoint-xl</code></a>
+                                  
+                                  
+                                          </li>
+                                  
+                                  
+                                  
+                                    </ul>
+                                  
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                                  
+                                  
+                                  
+                                  
+                                  
+                                  
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                            
+                            </section>  
+                          
+                        </section>  
+                    
+                  
+                  </section>
+                  
+              
               
               
               

--- a/docs/index.html
+++ b/docs/index.html
@@ -58435,16 +58435,16 @@
                               
                                 // Capture themeable variables from skin.
                                 $gap-column: map-deep-get($skin, &#x27;gap-column&#x27;);
-                                $gap-row-mobile: map-deep-get($skin, &#x27;gap-row.mobile&#x27;);
-                                $gap-row-large: map-deep-get($skin, &#x27;gap-row.large&#x27;);
+                                $gap-row-s: map-deep-get($skin, &#x27;gap-row.s&#x27;);
+                                $gap-row-xl: map-deep-get($skin, &#x27;gap-row.xl&#x27;);
                               
                               
                                 // Defines the flow-content-boxes component&#x27;s base styles.
-                                grid-row-gap: $gap-row-mobile;
+                                grid-row-gap: $gap-row-s;
                               
                                 @include breakpoint-xl() {
                                   grid-column-gap: $gap-column;
-                                  grid-row-gap: $gap-row-large;
+                                  grid-row-gap: $gap-row-xl;
                                 }
                               
                                 &amp;-feature { }
@@ -58635,9 +58635,9 @@
                               
                                 &#x27;gap-column&#x27;: 36px,
                                 &#x27;gap-row&#x27;: (
-                                  &#x27;mobile&#x27;: 23px,
-                                  &#x27;large&#x27;: 0,
-                                  )
+                                  &#x27;s&#x27;: 23px,
+                                  &#x27;xl&#x27;: 0,
+                                )
                               
                               );</code></pre>
                               
@@ -58748,23 +58748,33 @@
                                 grid-template-columns: 1fr;
                                 grid-template-rows: minmax(460px, min-content);
                               
-                                &amp;-feature{
+                                &amp;-feature {
                                   order: 2;
+                                  
+                                  @include breakpoint-xl {
+                                    order: unset;
+                                  };
+                                  
                                 }
                               
                                 &amp;-explorer {
                                   order: 1;
+                                  
+                                  @include breakpoint-xl {
+                                    order: unset;
+                                  };
+                                  
                                 }
                               
                                 @include breakpoint-xl() {
                                   grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
                               
                                   &amp;-feature{
-                                    grid-column: 1/span 1;
+                                    grid-column: 1;
                                   }
                               
                                   &amp;-explorer {
-                                    grid-column: 2/span 1;
+                                    grid-column: 2;
                                   }
                               
                                 }

--- a/pattern-status.json
+++ b/pattern-status.json
@@ -64,5 +64,6 @@
   "templates-service-directory": "review",
   "templates-research-help": "construction",
   "templates-subject-librarian-directory": "review",
-  "templates-staff-directory": "review"
+  "templates-staff-directory": "review",
+  "organisms-flow-content-boxes": "construction"
 }

--- a/pattern-status.json
+++ b/pattern-status.json
@@ -60,7 +60,7 @@
   "organisms-section-major": "review",
   "organisms-section-minor": "review",
   "organisms-intro-hero": "review",
-  "organisms-flow-content-boxes": "construction",
+  "organisms-flow-content-boxes": "review",
   "templates-info": "review",
   "templates-material": "review",
   "templates-tool": "review",

--- a/scss/emory-libraries/patterns/30-molecules/feature/_structure.scss
+++ b/scss/emory-libraries/patterns/30-molecules/feature/_structure.scss
@@ -6,10 +6,10 @@
 ///
 /// @since 1.0.0
 %molecules-feature {
-  
+
   // Capture selector.
   $selector: &;
-  
+
   // Builds the feature structure.
   display: grid;
   grid-template-areas: "image"
@@ -17,7 +17,7 @@
                        "heading"
                        "action";
   grid-template-rows: 250px repeat(3, min-content);
-  
+
   // Modifies structure for larger screens.
   @include breakpoint-m-l {
     grid-template-areas: "image context"
@@ -25,7 +25,7 @@
                          "image action";
     grid-template-rows: repeat(2, min-content) 1fr;
   };
-  
+
   // Modifies styles for descriptions.
   &.has-description {
     grid-template-areas: "image"
@@ -33,7 +33,7 @@
                          "heading"
                          "description"
                          "action";
-    
+
     // Modifies styles for descriptions.
     @include breakpoint-m-l {
       grid-template-areas: "image context"
@@ -42,37 +42,38 @@
                            "image action";
       grid-template-rows: repeat(2, min-content) auto 1fr;
     };
-    
+
   }
-  
+
   // Builds feature image structure.
   &-image {
     @include absolute( 0 );
     @include absolute-center-contents;
     grid-area: image;
     overflow: hidden;
-    
+
     img {
       width: 100%;
-      
+      object-fit: cover;
+
       @include breakpoint-m-l {
         height: 100%;
         width: auto;
         min-width: 100%;
       };
-      
+
     }
-    
+
     &::after {
       content: '';
       display: block;
       @include absolute( 0 );
     }
-    
+
     @include breakpoint-m-l {
       align-items: center;
     };
-    
+
     // Modifies structure in terms of image alignment.
     &.-align-x-left {
       justify-content: flex-start;
@@ -92,37 +93,37 @@
     &.-align-y-center {
       align-items: center;
     }
-    
+
   }
-  
+
   // Builds feature context structure.
   &-context {
     grid-area: context;
     margin: 0;
   }
-  
+
   // Builds feature heading structure.
   &-heading {
     grid-area: heading;
     margin: 0;
   }
-  
+
   // Builds feature description structure.
   &-description {
     grid-area: description;
     margin: 0;
     display: none;
-    
+
     // Requires a flag to show descriptions.
     @include when-descendant-of( '#{$selector}.has-description' ) {
       display: block;
     };
-    
+
   }
-  
+
   // Builds feature action structure.
   &-action {
     grid-area: action;
   }
-  
+
 }

--- a/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
+++ b/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
@@ -1,0 +1,40 @@
+////
+/// @group emory-libraries.patterns.organisms.flow-content-boxes
+////
+
+/// Load the flow-content-boxes component's structure and skin.
+@import 'flow-content-boxes/structure';
+@import 'flow-content-boxes/skin';
+
+/// Builds a constructor for the flow-content-boxes component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {placeholder} organisms-flow-content-boxes
+/// @requires {variable} organisms-flow-content-boxes
+/// @requires {mixin} organisms-flow-content-boxes--theme
+/// @requires {function} Brandy::map-extend <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend>
+///
+/// @param {map} $custom - A custom skin for the component
+///
+/// @output The native structure and skin of our flow-content-boxes component
+///
+/// @status construction
+@mixin organisms-flow-content-boxes ( $custom: () ) {
+
+  // Extend the default skin.
+  $skin: map-extend($organisms-flow-content-boxes, $custom);
+
+  // Initialize the flow-content-boxes component.
+  & {
+
+    // Load structure.
+    @extend %organisms-flow-content-boxes;
+
+
+    // Load skins.
+    @include organisms-flow-content-boxes--theme( $skin );
+
+  }
+
+}

--- a/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
+++ b/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
@@ -19,7 +19,7 @@
 ///
 /// @output The native structure and skin of our flow-content-boxes component
 ///
-/// @status construction
+/// @status review
 @mixin organisms-flow-content-boxes ( $custom: () ) {
 
   // Extend the default skin.

--- a/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
+++ b/scss/emory-libraries/patterns/50-organisms/_flow-content-boxes.scss
@@ -31,10 +31,16 @@
     // Load structure.
     @extend %organisms-flow-content-boxes;
 
-
     // Load skins.
     @include organisms-flow-content-boxes--theme( $skin );
 
   }
 
+  &-feature {
+    @extend %organisms-flow-content-boxes-feature;
+  }
+
+  &-explorer {
+    @extend %organisms-flow-content-boxes-explorer;
+  }
 }

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
@@ -1,0 +1,33 @@
+////
+/// @group emory-libraries.patterns.organisms.flow-content-boxes
+////
+
+/// Defines the base skin of the flow-content-boxes component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @type map
+$organisms-flow-content-boxes: (
+
+  'gap': 36px,
+
+);
+
+/// Defines the flow-content-boxes component theme.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {map} skin - The component's skin
+///
+/// @output The flow-content-explorer component's themeable properties
+@mixin organisms-flow-content-boxes--theme ( $skin ) {
+
+  // Capture themeable variables from skin.
+  $gap: map-deep-get($skin, 'gap');
+
+  // Defines the flow-content-boxes component's base styles.
+  grid-column-gap: $gap;
+
+}

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
@@ -9,7 +9,11 @@
 /// @type map
 $organisms-flow-content-boxes: (
 
-  'gap': 36px,
+  'gap-column': 36px,
+  'gap-row': (
+    'mobile': 23px,
+    'large': 0,
+    )
 
 );
 
@@ -25,9 +29,21 @@ $organisms-flow-content-boxes: (
 @mixin organisms-flow-content-boxes--theme ( $skin ) {
 
   // Capture themeable variables from skin.
-  $gap: map-deep-get($skin, 'gap');
+  $gap-column: map-deep-get($skin, 'gap-column');
+  $gap-row-mobile: map-deep-get($skin, 'gap-row.mobile');
+  $gap-row-large: map-deep-get($skin, 'gap-row.large');
+
 
   // Defines the flow-content-boxes component's base styles.
-  grid-column-gap: $gap;
+  grid-row-gap: $gap-row-mobile;
+
+  @include breakpoint-xl() {
+    grid-column-gap: $gap-column;
+    grid-row-gap: $gap-row-large;
+  }
+
+  &-feature { }
+
+  &-explorer { }
 
 }

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_skin.scss
@@ -11,9 +11,9 @@ $organisms-flow-content-boxes: (
 
   'gap-column': 36px,
   'gap-row': (
-    'mobile': 23px,
-    'large': 0,
-    )
+    's': 23px,
+    'xl': 0,
+  )
 
 );
 
@@ -30,16 +30,16 @@ $organisms-flow-content-boxes: (
 
   // Capture themeable variables from skin.
   $gap-column: map-deep-get($skin, 'gap-column');
-  $gap-row-mobile: map-deep-get($skin, 'gap-row.mobile');
-  $gap-row-large: map-deep-get($skin, 'gap-row.large');
+  $gap-row-s: map-deep-get($skin, 'gap-row.s');
+  $gap-row-xl: map-deep-get($skin, 'gap-row.xl');
 
 
   // Defines the flow-content-boxes component's base styles.
-  grid-row-gap: $gap-row-mobile;
+  grid-row-gap: $gap-row-s;
 
   @include breakpoint-xl() {
     grid-column-gap: $gap-column;
-    grid-row-gap: $gap-row-large;
+    grid-row-gap: $gap-row-xl;
   }
 
   &-feature { }

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
@@ -1,0 +1,30 @@
+////
+/// @group emory-libraries.patterns.organisms.flow-content-boxes
+////
+
+/// Defines the base structure of the flow-content-boxes component.
+///
+/// @since 1.0.0-dev.0
+%organisms-flow-content-boxes {
+
+  // Captures the selector.
+  $selector: &;
+
+  // Builds the flow-content-boxes structure.
+  // ...
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(460px, min-content);
+
+  &-feature{
+    grid-column: 1/span 1;
+  }
+
+  &-explorer {
+    grid-column: 2/span 1;
+  }
+
+  @include breakpoint-xl() {
+    grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
+  }
+}

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
@@ -17,14 +17,23 @@
   grid-template-rows: minmax(460px, min-content);
 
   &-feature{
-    grid-column: 1/span 1;
+    order: 2;
   }
 
   &-explorer {
-    grid-column: 2/span 1;
+    order: 1;
   }
 
   @include breakpoint-xl() {
     grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
+
+    &-feature{
+      grid-column: 1/span 1;
+    }
+
+    &-explorer {
+      grid-column: 2/span 1;
+    }
+
   }
 }

--- a/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
+++ b/scss/emory-libraries/patterns/50-organisms/flow-content-boxes/_structure.scss
@@ -16,23 +16,33 @@
   grid-template-columns: 1fr;
   grid-template-rows: minmax(460px, min-content);
 
-  &-feature{
+  &-feature {
     order: 2;
+    
+    @include breakpoint-xl {
+      order: unset;
+    };
+    
   }
 
   &-explorer {
     order: 1;
+    
+    @include breakpoint-xl {
+      order: unset;
+    };
+    
   }
 
   @include breakpoint-xl() {
     grid-template-columns: minmax(min-content, 2fr) minmax(min-content, 376px);
 
     &-feature{
-      grid-column: 1/span 1;
+      grid-column: 1;
     }
 
     &-explorer {
-      grid-column: 2/span 1;
+      grid-column: 2;
     }
 
   }

--- a/scss/emory-libraries/patterns/__master.scss
+++ b/scss/emory-libraries/patterns/__master.scss
@@ -93,6 +93,7 @@
 @import '50-organisms/section-major';
 @import '50-organisms/section-minor';
 @import '50-organisms/intro-hero';
+@import '50-organisms/flow-content-boxes';
 /*** INSERT NEW ORGANISMS HERE ***/
 
 

--- a/test/comps-organisms.html
+++ b/test/comps-organisms.html
@@ -11,7 +11,7 @@
 
   <!-- organisms-intro -->
   <div class="flow-content-boxes">
-    <div class="feature flow-content-feature">
+    <div class="feature flow-content-boxes-feature">
       <div class="feature-image">
         <img src="//source.unsplash.com/6fv1nBklWIU/500x650" alt="" class="image">
       </div>
@@ -21,7 +21,7 @@
         <a href="" role="button" class="button" target="_self">Continue Reading</a><a href="" role="button" class="button -hollow" target="_self">Consult a Subject Librarian</a>
       </div>
     </div>
-    <div class="explorer flow-content-explorer">
+    <div class="explorer flow-content-boxes-explorer">
       <span class="explorer-context">Explore</span>
       <span class="explorer-heading">Popular Links</span>
       <ul class="explorer-list">

--- a/test/comps-organisms.html
+++ b/test/comps-organisms.html
@@ -8,17 +8,44 @@
 
 <body>
 
+
+  <!-- organisms-intro -->
+  <div class="flow-content-boxes">
+    <div class="feature flow-content-feature">
+      <div class="feature-image">
+        <img src="//source.unsplash.com/6fv1nBklWIU/500x650" alt="" class="image">
+      </div>
+      <span class="feature-context">Confused About Research or an Assignment?</span>
+      <h4 class="feature-heading">Use the expertise of our subject librarians to get help finding sources, conducting research, and understanding an assignment or topic.</h4>
+      <div class="feature-action button-group">
+        <a href="" role="button" class="button" target="_self">Continue Reading</a><a href="" role="button" class="button -hollow" target="_self">Consult a Subject Librarian</a>
+      </div>
+    </div>
+    <div class="explorer flow-content-explorer">
+      <span class="explorer-context">Explore</span>
+      <span class="explorer-heading">Popular Links</span>
+      <ul class="explorer-list">
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Get Help with Your Research</a></li>
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Understand InterLibrary Loans</a></li>
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Find a Study Space or Reserve a Room</a></li>
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Access Course Reserves</a></li>
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Guest Access</a></li>
+        <li class="explorer-list-item"><a href="" class="link explorer-link" target="_self">Printing, Logging In, and Access</a></li>
+      </ul>
+    </div>
+  </div>
+
   <!-- organisms-intro -->
   <div>
 
     <!-- organisms-intro-hero -->
     <div>
       <header class="intro-hero">
-          <div class="intro-hero-image" style="background-image: url('https://source.unsplash.com/1450x440');"></div>
-          <div class="intro-hero-gradient"></div>
-          <div class="intro-hero-badge badge -white -square">Badge</div>
-          <h1 class="intro-hero-title">Instructional Services for Faculty and TAs</h1>
-          <p class="intro-hero-subtitle">We offer several services to support teaching and student learning.</p>
+        <div class="intro-hero-image" style="background-image: url('https://source.unsplash.com/1450x440');"></div>
+        <div class="intro-hero-gradient"></div>
+        <div class="intro-hero-badge badge -white -square">Badge</div>
+        <h1 class="intro-hero-title">Instructional Services for Faculty and TAs</h1>
+        <p class="intro-hero-subtitle">We offer several services to support teaching and student learning.</p>
       </header>
     </div>
 

--- a/test/comps-organisms.scss
+++ b/test/comps-organisms.scss
@@ -1,5 +1,10 @@
 @import 'comps-compounds';
 
+//organisms-flow-content-explorer
+.flow-content-boxes {
+  @include organisms-flow-content-boxes;
+}
+
 // organisms-intro
 .intro {
   @include organisms-intro;


### PR DESCRIPTION
This adds styles for organisms-flow~content-boxes (formerly organisms-flow~content-explorer).

I renamed the pattern because nesting the molecule-explorer partial within it ending up giving it the same class name when using our naming conventions (i.e. the selector would have been `.flow-content-explorer .flow-content-explorer`). 