### PR TITLE
Adds styles for `organisms-nav-bar-main`

### DIFF
--- a/pattern-status.json
+++ b/pattern-status.json
@@ -80,5 +80,6 @@
   "templates-gallery": "review",
   "templates-research-help-directory": "review",
   "templates-landing": "construction",
-  "templates-exhibition": "review"
+  "templates-exhibition": "review",
+  "compounds-nav-menu-main": "construction"
 }

--- a/pattern-status.json
+++ b/pattern-status.json
@@ -80,5 +80,6 @@
   "templates-gallery": "review",
   "templates-research-help-directory": "review",
   "templates-landing": "construction",
-  "templates-exhibition": "review"
+  "templates-exhibition": "review",
+  "organisms-nav-bar-main": "construction"
 }

--- a/pattern-status.json
+++ b/pattern-status.json
@@ -82,5 +82,5 @@
   "templates-gallery": "review",
   "templates-research-help-directory": "review",
   "templates-landing": "construction",
-  "templates-exhibition": "review",
+  "templates-exhibition": "review"
 }

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
@@ -436,12 +436,14 @@ $atoms-nav-button: (
     'x': (
       's': 10px,
       'm': 10px,
-      'l': 25px
+      'l': 15px,
+      'xl': 25px
     ),
     'y': (
       's': false,
       'm': false,
-      'l': false
+      'l': false,
+      'xl': false
     )
   )
 

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
@@ -573,7 +573,7 @@ $atoms-nav-button: (
     }
 
     // Remove border from first button.
-    @include first-child {
+    &:first-child {
 
       // Remove border.
       &::before {

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
@@ -1071,7 +1071,7 @@ $atoms-nav-button: (
 
         // Apply indicator styles.
         &::after {
-          @include breakpoint-m-l {
+          @include breakpoint-l {
             @include size($indicator-size);
             border: $indicator-border;
             background-color: $indicator-color;
@@ -1130,7 +1130,7 @@ $atoms-nav-button: (
 
       // Apply indicator styles.
       &::after {
-        @include breakpoint-m-l {
+        @include breakpoint-l {
           @include size($indicator-size);
           border: $indicator-border;
           background-color: $indicator-color;

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
@@ -13,34 +13,34 @@ $atoms-nav-button: (
     'foreground': (
       'normal': (
         's': color('white'),
-        'm': color('blue', 'dark'),
+        'm': color('white'),
         'l': color('blue', 'dark')
       ),
       'hover': (
         's': color('white'),
-        'm': $color-actionable,
+        'm': color('white'),
         'l': $color-actionable
       ),
       'active': (
         's': color('white'),
-        'm': $color-actionable,
+        'm': color('white'),
         'l': $color-actionable
       )
     ),
     'background': (
       'normal': (
         's': color('blue', 'dark'),
-        'm': color('white'),
+        'm': color('blue', 'dark'),
         'l': color('white')
       ),
       'hover': (
         's': color('blue'),
-        'm': color('white'),
+        'm': color('blue'),
         'l': color('white')
       ),
       'active': (
         's': color('blue'),
-        'm': color('white'),
+        'm': color('blue'),
         'l': color('white')
       )
     ),
@@ -50,12 +50,12 @@ $atoms-nav-button: (
       'font-style': normal,
       'font-size': (
         's': $font-size,
-        'm': 14px,
+        'm': $font-size,
         'l': 14px
       ),
       'line-height': (
         's': 2.0625,
-        'm': 1.5,
+        'm': 2.0625,
         'l': 1.5
       ),
       'text-transform': (
@@ -72,6 +72,14 @@ $atoms-nav-button: (
     'border': (
       'thickness': $border-width-s,
       'color': color('slate', 'light')
+    ),
+    'indicator': (
+      'size': 8px,
+      'color': color('gold'),
+      'border': (
+        'thickness': $border-width-l,
+        'color': color('blue', 'dark')
+      )
     )
   ),
 
@@ -79,34 +87,34 @@ $atoms-nav-button: (
     'foreground': (
       'normal': (
         's': color('white'),
-        'm': color('blue', 'mid'),
+        'm': color('white'),
         'l': color('blue', 'mid')
       ),
       'hover': (
         's': color('white'),
-        'm': $color-actionable,
+        'm': color('white'),
         'l': $color-actionable
       ),
       'active': (
         's': color('white'),
-        'm': $color-actionable,
+        'm': color('white'),
         'l': $color-actionable
       )
     ),
     'background': (
       'normal': (
         's': color('blue', 'dark'),
-        'm': color('white'),
+        'm': color('blue', 'dark'),
         'l': color('white')
       ),
       'hover': (
         's': color('blue'),
-        'm': color('white'),
+        'm': color('blue'),
         'l': color('white')
       ),
       'active': (
         's': color('blue'),
-        'm': color('white'),
+        'm': color('blue'),
         'l': color('white')
       )
     ),
@@ -116,22 +124,22 @@ $atoms-nav-button: (
       'font-style': normal,
       'font-size': (
         's': $font-size,
-        'm': 11px,
+        'm': $font-size,
         'l': 11px
       ),
       'line-height': (
         's': 2.0625,
-        'm': 1.6364,
+        'm': 2.0625,
         'l': 1.6364
       ),
       'text-transform': (
         's': normal,
-        'm': uppercase,
+        'm': normal,
         'l': uppercase
       ),
       'letter-spacing': (
         's': none,
-        'm': 0.05em,
+        'm': none,
         'l': 0.05em
       )
     )
@@ -373,29 +381,29 @@ $atoms-nav-button: (
       'font-style': normal,
       'font-size': (
         's': 11px,
-        'm': 0,
+        'm': 11px,
         'l': 0
       ),
       'line-height': (
         's': 1.6364,
-        'm': 0,
+        'm': 1.6364,
         'l': 0
       ),
       'text-transform': (
         's': uppercase,
-        'm': none,
+        'm': uppercase,
         'l': none
       ),
       'letter-spacing': (
-        's': 0.05em,
-        'm': normal,
+        's': .05em,
+        'm': .05em,
         'l': normal
       )
     ),
     'icon': (
       'size': (
         's': 24px,
-        'm': 0,
+        'm': 24px,
         'l': 0
       )
     ),
@@ -407,7 +415,7 @@ $atoms-nav-button: (
       ),
       'y': (
         's': 10px,
-        'm': false,
+        'm': 10px,
         'l': false
       )
     )
@@ -427,7 +435,7 @@ $atoms-nav-button: (
   'padding': (
     'x': (
       's': 10px,
-      'm': 25px,
+      'm': 10px,
       'l': 25px
     ),
     'y': (
@@ -549,6 +557,7 @@ $atoms-nav-button: (
         };
       }
 
+      .input.-toggle:checked + &,
       &:hover,
       &:focus,
       &.is-hover,
@@ -606,6 +615,7 @@ $atoms-nav-button: (
         };
       }
 
+      .input.-toggle:checked + &,
       &:hover,
       &:focus,
       &.is-hover,
@@ -641,15 +651,13 @@ $atoms-nav-button: (
     $padding: map-deep-get($skin, 'padding.x.s');
 
     // Add arrow to button only on small screens.
-    padding-right: ($padding * 2) + $arrow-size + $padding;
+    @include breakpoint-s {
+      padding-right: ($padding * 2) + $arrow-size + $padding;
+    };
 
     // Add icon to button.
     &::after {
       @include tokens-icon('material-chevron_right', $arrow-color, $arrow-size, $pseudo: true);
-      @include padding-x( 10px );
-      @include absolute( 0 0 0 null );
-      @include absolute-center-within-container-y;
-      @include absolute-center-contents;
       @include size( $arrow-size );
       color: $arrow-color;
       line-height: 1;
@@ -661,12 +669,8 @@ $atoms-nav-button: (
 
     // Add border to button.
     &::before {
-      content: '';
-      display: block;
-      @include absolute(0 0 null 0);
       height: $border-thickness;
       background-color: $border-color;
-      @include margin-x( auto );
       opacity: .15;
       width: calc(100% - #{$padding * 2});
     }
@@ -683,16 +687,22 @@ $atoms-nav-button: (
 
     // Remove arrow from button on larger screens.
     @include breakpoint-m-l {
-      padding-right: 10px;
 
-      // Remove icon from button.
-      &::after {
-        content: none;
-      }
+      // Get indicator-specific variables.
+      $indicator-size: map-deep-get($skin, 'main.indicator.size');
+      $indicator-color: map-deep-get($skin, 'main.indicator.color');
+      $indicator-border-thickness: map-deep-get($skin, 'main.indicator.border.thickness');
+      $indicator-border-color: map-deep-get($skin, 'main.indicator.border.color');
+      $indicator-border: $indicator-border-thickness solid $indicator-border-color;
 
-      // Remove border from button.
-      &::before {
-        content: none;
+      // Add indicator to button.
+      .input.-toggle:checked + &::after,
+      &:focus::after,
+      &.is-focus::after {
+        @include size($indicator-size);
+        border: $indicator-border;
+        background-color: $indicator-color;
+        transform: rotate(45deg) translatey(calc(50% + #{$indicator-border-thickness} + 1px));
       }
 
     };
@@ -746,6 +756,7 @@ $atoms-nav-button: (
 
       }
 
+      //.input.-toggle:checked ~ .nav-menu-main-toggles &,
       &:hover,
       &:focus,
       &.is-hover,
@@ -778,6 +789,7 @@ $atoms-nav-button: (
 
       background-color: $normal;
 
+      //.input.-toggle:checked ~ .nav-menu-main-toggles &,
       &:hover,
       &:focus,
       &.is-hover,
@@ -1073,7 +1085,7 @@ $atoms-nav-button: (
       color: $arrow-color;
       line-height: 1;
     }
-    
+
     @include breakpoint-l {
       @include padding-x(10px);
     };
@@ -1093,7 +1105,7 @@ $atoms-nav-button: (
       };
 
     }
-    
+
     @include breakpoint-l {
       @include padding-x(10px);
     };

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_skin.scss
@@ -532,115 +532,10 @@ $atoms-nav-button: (
 
     }
 
-    $foreground: map-deep-get($skin, 'main.foreground');
-    $background: map-deep-get($skin, 'main.background');
-
-    // Apply foreground styles.
-    @include private('Foreground') {
-
-      $normal: map-get($foreground, 'normal');
-      $hover: map-get($foreground, 'hover');
-      $active: map-get($foreground, 'active');
-
-      @each $breakpoint, $color in $normal {
-        @include breakpoint( screen($breakpoint) ) {
-          color: $color;
-
-          .icon {
-
-            svg {
-              fill: $color;
-            }
-
-          }
-
-        };
-      }
-
-      .input.-toggle:checked + &,
-      &:hover,
-      &:focus,
-      &.is-hover,
-      &.is-focus {
-
-        @each $breakpoint, $color in $hover {
-          @include breakpoint( screen($breakpoint) ) {
-            color: $color;
-
-            .icon {
-
-              svg {
-                fill: $color;
-              }
-
-            }
-
-          };
-        }
-
-      }
-
-      &:active,
-      &.is-active {
-
-        @each $breakpoint, $color in $active {
-          @include breakpoint( screen($breakpoint) ) {
-            color: $color;
-
-            .icon {
-
-              svg {
-                fill: $color;
-              }
-
-            }
-
-          };
-        }
-
-      }
-
-    };
-
-    // Apply background styles.
-    @include private('Background') {
-
-      $normal: map-get($background, 'normal');
-      $hover: map-get($background, 'hover');
-      $active: map-get($background, 'active');
-
-      @each $breakpoint, $color in $normal {
-        @include breakpoint( screen($breakpoint) ) {
-          background-color: $color;
-        };
-      }
-
-      .input.-toggle:checked + &,
-      &:hover,
-      &:focus,
-      &.is-hover,
-      &.is-focus {
-
-        @each $breakpoint, $color in $hover {
-          @include breakpoint( screen($breakpoint) ) {
-          background-color: $color;
-        };
-        }
-
-      }
-
-      &:active,
-      &.is-active {
-
-        @each $breakpoint, $color in $active {
-          @include breakpoint( screen($breakpoint) ) {
-            background-color: $color;
-          };
-        }
-
-      }
-
-    };
+    @include atoms-nav-button--state('normal', $skin);
+    @include atoms-nav-button--state('hover', $skin);
+    @include atoms-nav-button--state('focus', $skin);
+    @include atoms-nav-button--state('active', $skin);
 
     // Don't allow icons on main buttons.
     .icon {
@@ -681,28 +576,6 @@ $atoms-nav-button: (
       // Remove border.
       &::before {
         content: none;
-      }
-
-    };
-
-    // Remove arrow from button on larger screens.
-    @include breakpoint-m-l {
-
-      // Get indicator-specific variables.
-      $indicator-size: map-deep-get($skin, 'main.indicator.size');
-      $indicator-color: map-deep-get($skin, 'main.indicator.color');
-      $indicator-border-thickness: map-deep-get($skin, 'main.indicator.border.thickness');
-      $indicator-border-color: map-deep-get($skin, 'main.indicator.border.color');
-      $indicator-border: $indicator-border-thickness solid $indicator-border-color;
-
-      // Add indicator to button.
-      .input.-toggle:checked + &::after,
-      &:focus::after,
-      &.is-focus::after {
-        @include size($indicator-size);
-        border: $indicator-border;
-        background-color: $indicator-color;
-        transform: rotate(45deg) translatey(calc(50% + #{$indicator-border-thickness} + 1px));
       }
 
     };
@@ -1127,6 +1000,146 @@ $atoms-nav-button: (
   &[disabled],
   &.is-disabled {
     opacity: .5;
+  }
+
+}
+
+/// Defines the nav-button component state.
+///
+/// @since 1.0.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {string} state - The component's state to be styled
+/// @param {map} skin - The component's skin
+///
+/// @output The nav-button component's themeable properties
+@mixin atoms-nav-button--state( $state, $skin: $atoms-nav-button, $selector: true ) {
+
+  // For focus states, use the hover state.
+  $target: if($state == 'focus', 'hover', $state);
+
+  // Get variables for focus state.
+  $foreground: map-deep-get($skin, 'main.foreground.' + $target);
+  $background: map-deep-get($skin, 'main.background.' + $target);
+
+  @if( $selector and $state != 'normal' ) {
+
+    &:#{$state},
+    &.is-#{$state} {
+
+      // Apply foreground styles.
+      @include private('Foreground') {
+
+        @each $breakpoint, $color in $foreground {
+          @include breakpoint( screen($breakpoint) ) {
+            color: $color;
+
+            .icon {
+
+              svg {
+                fill: $color;
+              }
+
+            }
+
+          };
+        }
+
+      };
+
+      // Apply background styles.
+      @include private('Background') {
+
+        @each $breakpoint, $color in $background {
+          @include breakpoint( screen($breakpoint) ) {
+            background-color: $color;
+          };
+        }
+
+      };
+
+      // Add indicators to focus state.
+      @if( $state == 'focus' ) {
+
+        // Get indicator-specific variables.
+        $indicator-size: map-deep-get($skin, 'main.indicator.size');
+        $indicator-color: map-deep-get($skin, 'main.indicator.color');
+        $indicator-border-thickness: map-deep-get($skin, 'main.indicator.border.thickness');
+        $indicator-border-color: map-deep-get($skin, 'main.indicator.border.color');
+        $indicator-border: $indicator-border-thickness solid $indicator-border-color;
+
+        // Apply indicator styles.
+        &::after {
+          @include breakpoint-m-l {
+            @include size($indicator-size);
+            border: $indicator-border;
+            background-color: $indicator-color;
+            transform: rotate(45deg) translatey(calc(50% + #{$indicator-border-thickness} + 1px));
+          };
+        }
+
+      }
+
+    }
+
+  }
+
+  @else {
+
+    // Apply foreground styles.
+    @include private('Foreground') {
+
+      @each $breakpoint, $color in $foreground {
+        @include breakpoint( screen($breakpoint) ) {
+          color: $color;
+
+          .icon {
+
+            svg {
+              fill: $color;
+            }
+
+          }
+
+        };
+      }
+
+    };
+
+    // Apply background styles.
+    @include private('Background') {
+
+      @each $breakpoint, $color in $background {
+        @include breakpoint( screen($breakpoint) ) {
+          background-color: $color;
+        };
+      }
+
+    };
+
+    // Add indicators to focus state.
+    @if( $state == 'focus' ) {
+
+      // Get indicator-specific variables.
+      $indicator-size: map-deep-get($skin, 'main.indicator.size');
+      $indicator-color: map-deep-get($skin, 'main.indicator.color');
+      $indicator-border-thickness: map-deep-get($skin, 'main.indicator.border.thickness');
+      $indicator-border-color: map-deep-get($skin, 'main.indicator.border.color');
+      $indicator-border: $indicator-border-thickness solid $indicator-border-color;
+
+      // Apply indicator styles.
+      &::after {
+        @include breakpoint-m-l {
+          @include size($indicator-size);
+          border: $indicator-border;
+          background-color: $indicator-color;
+          transform: rotate(45deg) translatey(calc(50% + #{$indicator-border-thickness} + 1px));
+        };
+      }
+
+    }
+
   }
 
 }

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
@@ -88,6 +88,7 @@
       @include absolute(0 0 0 null);
       @include absolute-center-within-container-y;
       @include absolute-center-contents;
+      box-sizing: content-box;
     }
 
     @include breakpoint-l {
@@ -178,7 +179,7 @@
     height: 45px;
     justify-content: center;
 
-    @include breakpoint-m-l {
+    @include breakpoint-l {
       height: 40px;
       flex-direction: row;
     };

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: flex-start;
   width: 100%;
+  overflow: hidden;
 
   // Adds breakpoint-specific structure changes.
   @include breakpoint-l {
@@ -30,8 +31,41 @@
   &.-main {
     height: 60px;
 
-    @include breakpoint-m-l {
+    &::before {
+      content: '';
+      display: block;
+      @include absolute(0 0 null 0);
+      @include margin-x(auto);
+    }
+
+    &::after {
+      content: '';
+      @include padding-x(10px);
+      @include absolute(0 0 0 null);
+      @include absolute-center-within-container-y;
+      @include absolute-center-contents;
+    }
+
+    @include breakpoint-l {
       height: 90px;
+
+      &::before {
+        content: none !important;
+      }
+
+      &::after {
+        content: none !important;
+      }
+
+      .input.-toggle:checked + &::after,
+      &:focus::after,
+      &.is-focus::after {
+        content: '' !important;
+        display: block;
+        @include absolute(unset 0 0 50%);
+        @include padding-x(0);
+      }
+
     };
 
   }
@@ -43,7 +77,7 @@
     justify-content: center;
     width: auto;
 
-    @include breakpoint-m-l {
+    @include breakpoint-l {
       display: none;
     };
 
@@ -67,7 +101,7 @@
   // Sets utility button structure.
   &.-utility {
     height: 60px;
-    
+
     // Don't allow icons on utility buttons.
     .icon {
       display: none;
@@ -76,11 +110,11 @@
     @include breakpoint-l {
       height: 40px;
       flex-direction: row;
-      
+
       &::after {
         content: none !important;
       }
-      
+
     };
 
   }

--- a/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
+++ b/scss/emory-libraries/patterns/20-atoms/nav-button/_structure.scss
@@ -2,6 +2,50 @@
 /// @group emory-libraries.patterns.atoms.nav-button
 ////
 
+/// Defines the nav-button component state structure.
+///
+/// @since 1.0.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {string} state - The component's state to be structure
+///
+/// @output The nav-button component's themeable properties
+@mixin atoms-nav-button--state--structure( $state, $selector: true ) {
+
+  @if( $selector and $state != 'normal' ) {
+
+    &:#{$state},
+    &.is-#{$state} {
+
+      @if( $state == 'focus' ) {
+        &::after {
+          content: '' !important;
+          display: block;
+          @include absolute(unset 0 0 50%);
+          @include padding-x(0);
+        }
+      }
+
+    }
+
+  }
+
+  @else {
+
+    @if( $state == 'focus' ) {
+      &::after {
+        content: '' !important;
+        display: block;
+        @include absolute(unset 0 0 50%);
+        @include padding-x(0);
+      }
+    }
+
+  }
+
+}
+
 /// Defines the base structure of the nav-button component.
 ///
 /// @since 1.0.0
@@ -57,14 +101,7 @@
         content: none !important;
       }
 
-      .input.-toggle:checked + &::after,
-      &:focus::after,
-      &.is-focus::after {
-        content: '' !important;
-        display: block;
-        @include absolute(unset 0 0 50%);
-        @include padding-x(0);
-      }
+      @include atoms-nav-button--state--structure('focus');
 
     };
 

--- a/scss/emory-libraries/patterns/20-atoms/subnav-button/_structure.scss
+++ b/scss/emory-libraries/patterns/20-atoms/subnav-button/_structure.scss
@@ -6,10 +6,10 @@
 ///
 /// @since 1.0.0
 %atoms-subnav-button {
-  
+
   // Capture selector.
   $selector: &;
-  
+
   // Builds the subnav-button structure.
   @extend %atoms-button;
   display: flex;
@@ -19,60 +19,67 @@
   min-height: 55px;
   height: auto;
   width: 100%;
-  
+
   // Modify styles on larger screens.
   @include breakpoint-m-l {
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;
   };
-  
+
   // Apply icon structure.
   .icon {
     @include absolute-center-contents;
   }
-  
+
   // Modifies main button structure.
   &:not(.-utility):not(.-viewall):not(.-back):not(.-resource),
   &.-main { }
-  
+
   // Modifies utility button structure.
   &.-utility { }
-  
+
   // Modifies view all button structure.
   &.-viewall {
-    
+    position: sticky;
+    bottom: 0;
+
     // Adjusts structure on large screens.
     @include breakpoint-l {
       @include absolute-center-contents;
       min-height: 75px;
+      position: relative;
+      bottom: unset;
     };
-    
+
     // Make the button dismissable.
     &.is-dismissed {
       display: none;
     }
-    
+
   }
-  
+
   // Modifies back button structure.
-  &.-back { 
+  &.-back {
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;
-    
+    position: sticky;
+    top: 0;
+    z-index: z('above');
+
     // Adds icon structure.
     &::before {
       @include absolute-center-contents;
     }
-    
+
     // Always hide back buttons on large screens.
     @include breakpoint-l {
       display: none;
     };
-    
+
   }
-  
+
   // Modifies resource button structure.
   &.-resource {
 
@@ -80,82 +87,82 @@
     #{$selector}-options {
       display: flex;
       @include absolute(0 0 0);
-      
+
       // Builds toggle structure.
       &-toggle {
         display: none;
       }
-      
+
     }
-    
+
     // Builds option structure.
-    #{$selector}-option { 
+    #{$selector}-option {
       @include absolute-center-contents;
       align-self: stretch;
     }
-    
+
   }
-  
+
   /* COMPONENT PARTS */
-  
+
   // Defines structure of button aliases.
   &-alias {
     display: flex;
     justify-content: flex-start;
-    
+
     // Adjusts structure on larger screens.
     @include breakpoint-m-l {
       @include size( auto );
     };
-    
+
   }
-  
+
   /* COMPONENT ACCESSORIES */
-  
+
   // Defines structure of grouped and categorized buttons.
   &-group,
   &-category {
-    
+
     // Builds structure of group and category headings.
     &-heading {
       min-height: 0;
       display: block;
     }
-    
+
   }
-  
+
   // Defines structure of grouped buttons.
   &-group {
-    
+
     // Modifies grouped button structure.
     &:not(.-utility),
     &.-main { }
-    
+
     // Adjust structure of buttons.
     #{$selector} {
-      
+
       @include breakpoint-l {
         min-height: 35px;
       };
-      
+
     }
-    
+
   }
-  
+
   // Defines structure of categorized buttons.
   &-category {
-    
+
     // Modifies categorized button structure.
     &:not(.-utility),
     &.-main {
       min-height: 0;
     }
-    
+
   }
 
   // Defines structure of overflow.
   &-overflow {
-    
+
     // Builds toggle structure.
     &-toggle {
       display: none;
@@ -170,5 +177,5 @@
   &.is-disabled {
     opacity: .5;
   }
-  
+
 }

--- a/scss/emory-libraries/patterns/30-molecules/branding-header/_skin.scss
+++ b/scss/emory-libraries/patterns/30-molecules/branding-header/_skin.scss
@@ -8,17 +8,17 @@
 ///
 /// @type map
 $molecules-branding-header: (
-  
+
   'background': color('white'),
   'organization': color('blue', 'dark'),
   'division': color('blue', 'dark'),
-  
+
   'dropdown': (
     'color': color('blue', 'bright'),
     'spacing': 1em,
     'icon': 15px
   ),
-  
+
   'badge': (
     'color': color('blue', 'mid'),
     'stroke': 10px,
@@ -27,18 +27,18 @@ $molecules-branding-header: (
       'max': 100px
     )
   ),
-  
+
   'transition': (
     'duration': $transition-duration,
     'timing': $transition-timing
   ),
-  
+
   'gap': 5px,
   'padding': (
     'x': 30px,
     'y': 20px
   )
-  
+
 );
 
 /// Defines the branding-header component theme.
@@ -51,7 +51,7 @@ $molecules-branding-header: (
 ///
 /// @output The branding-header component's themeable properties
 @mixin molecules-branding-header--theme ( $skin ) {
-  
+
   // Capture themeable variables from skin.
   $background: map-deep-get($skin, 'background');
   $organization: map-deep-get($skin, 'organization');
@@ -59,62 +59,61 @@ $molecules-branding-header: (
   $gap: map-deep-get($skin, 'gap');
   $padding-x: map-deep-get($skin, 'padding.x');
   $padding-y: map-deep-get($skin, 'padding.y');
-  
+
   // Get transition-specific variables.
   $transition-duration: map-deep-get($skin, 'transition.duration');
   $transition-timing: map-deep-get($skin, 'transition.timing');
-  
+
   // Get badge-specific variables.
   $badge-min: map-deep-get($skin, 'badge.size.min');
   $badge-max: map-deep-get($skin, 'badge.size.max');
   $badge-scale: numeric-scale($badge-min, $badge-max, 3, true);
   $badge-color: map-deep-get($skin, 'badge.color');
   $badge-stroke: map-deep-get($skin, 'badge.stroke');
-  
+
   // Get dropdown-specific variables.
   $dropdown-color: map-deep-get($skin, 'dropdown.color');
   $dropdown-spacing: map-deep-get($skin, 'dropdown.spacing');
   $dropdown-icon: map-deep-get($skin, 'dropdown.icon');
-  
+
   // Defines the branding-header component's base styles.
   padding: $padding-y $padding-x;
   grid-column-gap: $gap;
   background-color: $background;
-  
+
   // Defines the branding badge styles.
-  &-badge { 
+  &-badge {
     display: block;
     transition: all $transition-duration $transition-timing;
     width: nth($badge-scale, 1);
-    
+
     svg {
       height: nth($badge-scale, 1) + $badge-stroke;
     }
-    
-    @include breakpoint-m {
+
+    @include breakpoint-l {
       width: nth($badge-scale, 2);
-      
+
       svg {
-        top: -$padding-y;
         height: nth($badge-scale, 2) + $badge-stroke;
       }
-      
+
     }
-    
-    @include breakpoint-l {
+
+    @include breakpoint-xl {
       width: nth($badge-scale, 3);
-      
+
       svg {
         top: -$padding-y;
         height: nth($badge-scale, 3) + $badge-stroke;
       }
-      
+
     }
-    
+
     .logo {
       &:nth-child(1) svg {
         fill: transparent;
-        stroke-width: $badge-stroke * 2; 
+        stroke-width: $badge-stroke * 2;
         stroke: $background;
       }
       &:nth-child(2) svg {
@@ -122,9 +121,9 @@ $molecules-branding-header: (
         z-index: z('above');
       }
     }
-  
+
   }
-  
+
   // Defines the branding organization styles.
   &-organization {
     @include tokens-text('accent', $organization, ('accent': (
@@ -132,43 +131,43 @@ $molecules-branding-header: (
     )));
     font-size: 10px !important;
     transition: all $transition-duration $transition-timing;
-    
-    @include breakpoint-m-l {
+
+    @include breakpoint-l {
       font-size: 14px !important;
     };
-    
+
   }
-  
+
   // Defines the branding division styles.
   &-division {
     @include tokens-heading('h3', $division, ('h3': (
-      'line-height': 1  
+      'line-height': 1
     )));
     font-size: 18px !important;
     transition: all $transition-duration $transition-timing;
-    
-    @include breakpoint-m-l {
+
+    @include breakpoint-l {
       font-size: 24px !important;
     };
-    
+
   }
-  
+
   // Defines the branding dropdown styles.
-  &-dropdown { 
-  
+  &-dropdown {
+
     // Defines the branding dropdown menu styles.
     &-menu {
       @include tokens-text('button', $dropdown-color);
       background-image: icon-url('material-chevron_down', $dropdown-color, $dropdown-icon);
       background-size: $dropdown-icon;
       padding-right: $dropdown-icon;
-      
-      @include breakpoint-m-l {
+
+      @include breakpoint-xl {
         margin-left: $dropdown-spacing;
       };
-      
-    } 
-  
+
+    }
+
   }
-  
+
 }

--- a/scss/emory-libraries/patterns/30-molecules/branding-header/_structure.scss
+++ b/scss/emory-libraries/patterns/30-molecules/branding-header/_structure.scss
@@ -6,7 +6,7 @@
 ///
 /// @since 1.0.0-dev.0
 %molecules-branding-header {
-  
+
   // Builds the branding-header structure.
   display: grid;
   grid-template-areas: "badge organization"
@@ -14,55 +14,55 @@
                        "badge dropdown";
   grid-template-columns: min-content max-content;
   grid-template-rows: repeat(3, min-content);
-  
-  @include breakpoint-m-l {
+
+  @include breakpoint-xl {
     grid-template-areas: "badge organization organization"
                          "badge division dropdown";
     grid-template-columns: min-content max-content min-content;
     grid-template-rows: repeat(2, min-content);
   };
-  
+
   // Builds the branding badge structure.
-  &-badge { 
+  &-badge {
     grid-area: badge;
-    
-    .logo { 
+
+    .logo {
       @include size(100%);
       @include absolute-center-within-container;
     }
-    
+
     svg {
       @include absolute-center-within-container;
       width: 100%;
-      
-      @include breakpoint-m-l {
+
+      @include breakpoint-xl {
         @include absolute-center-within-container-x;
         top: 0;
       };
-      
+
     }
-    
+
   }
-  
+
   // Builds the branding organization structure.
   &-organization {
     grid-area: organization;
   }
-  
+
   // Builds the branding division structure.
   &-division {
     grid-area: division;
   }
-  
+
   // Builds the branding dropdown structure.
-  &-dropdown { 
+  &-dropdown {
     grid-area: dropdown;
     display: flex;
     align-items: flex-end;
     width: min-content;
-    
+
     // Builds the branding dropdown menu structure.
-    &-menu { 
+    &-menu {
       -webkit-appearance: none;
       -moz-appearance: none;
       appearance: none;
@@ -71,7 +71,7 @@
       max-width: 130px;
       background-repeat: no-repeat;
       background-position: right 70%;
-      
+
       option {
         margin: 0;
         padding: 0;
@@ -79,9 +79,9 @@
         -moz-appearance: none;
         appearance: none;
       }
-      
-    } 
-  
+
+    }
+
   }
-  
+
 }

--- a/scss/emory-libraries/patterns/40-compounds/_nav-menu-main.scss
+++ b/scss/emory-libraries/patterns/40-compounds/_nav-menu-main.scss
@@ -32,16 +32,19 @@
     @extend %compounds-nav-menu-main;
 
     // Load parts.
-    &-group {
-      @extend %compounds-nav-menu-main-group;
-    }
-    &-toggles {
-      @extend %compounds-nav-menu-main-toggles;
-    }
-    &-menu {
-      @extend %compounds-nav-menu-main-menu;
-      &-area {
-        @extend %compounds-nav-menu-main-menu-area;
+    &-nav {
+      @extend %compounds-nav-menu-main-nav;
+      &-group {
+        @extend %compounds-nav-menu-main-nav-group;
+      }
+      &-toggles {
+        @extend %compounds-nav-menu-main-nav-toggles;
+      }
+      &-menu {
+        @extend %compounds-nav-menu-main-nav-menu;
+        &-area {
+          @extend %compounds-nav-menu-main-nav-menu-area;
+        }
       }
     }
 

--- a/scss/emory-libraries/patterns/40-compounds/_nav-menu-main.scss
+++ b/scss/emory-libraries/patterns/40-compounds/_nav-menu-main.scss
@@ -1,0 +1,53 @@
+////
+/// @group emory-libraries.patterns.compounds.nav-menu-main
+////
+
+/// Load the nav-menu-main component's structure and skin.
+@import 'nav-menu-main/structure';
+@import 'nav-menu-main/skin';
+
+/// Builds a constructor for the nav-menu-main component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {placeholder} compounds-nav-menu-main
+/// @requires {variable} compounds-nav-menu-main
+/// @requires {mixin} compounds-nav-menu-main--theme
+/// @requires {function} Brandy::map-extend <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend>
+///
+/// @param {map} $custom - A custom skin for the component
+///
+/// @output The native structure and skin of our nav-menu-main component
+///
+/// @status construction
+@mixin compounds-nav-menu-main ( $custom: () ) {
+
+  // Extend the default skin.
+  $skin: map-extend($compounds-nav-menu-main, $custom);
+
+  // Initialize the nav-menu-main component.
+  & {
+
+    // Load structure.
+    @extend %compounds-nav-menu-main;
+
+    // Load parts.
+    &-group {
+      @extend %compounds-nav-menu-main-group;
+    }
+    &-toggles {
+      @extend %compounds-nav-menu-main-toggles;
+    }
+    &-menu {
+      @extend %compounds-nav-menu-main-menu;
+      &-area {
+        @extend %compounds-nav-menu-main-menu-area;
+      }
+    }
+
+    // Load skins.
+    @include compounds-nav-menu-main--theme( $skin );
+
+  }
+
+}

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_skin.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_skin.scss
@@ -10,7 +10,7 @@
 $compounds-nav-menu-main: (
 
   'background': color('white'),
-  'mobile': color('blue', 'dark'),
+  'menu': color('blue', 'dark'),
 
   'separator': (
     'thickness': $border-width-s,
@@ -35,12 +35,14 @@ $compounds-nav-menu-main: (
 /// @output The nav-menu-main component's themeable properties
 @mixin compounds-nav-menu-main--theme ( $skin ) {
 
-  // Capture selector.
+  // Capture selectors.
   $selector: &;
+  $selector-toggle: unquote('.input.-toggle');
+  $selector-subnavigation: unquote('.subnav-menu-main');
 
   // Capture themeable variables from skin.
   $background: map-deep-get($skin, 'background');
-  $mobile: map-deep-get($skin, 'mobile');
+  $menu: map-deep-get($skin, 'menu');
 
   // Get transition-specific variables.
   $transition-duration: map-deep-get($skin, 'transition.duration');
@@ -51,35 +53,29 @@ $compounds-nav-menu-main: (
   $separator-color: map-deep-get($skin, 'separator.color');
 
   // Defines the nav-menu-main component's base styles.
-  // ...
-
-  // Apply background styles.
-  &,
-  &-toggles {
-    background-color: $background;
-  }
-
-  // Define styles for mobile navigation menu.
-  &-menu {
-    transition: all $transition-duration $transition-timing;
-  }
+  background-color: $background;
 
   // Override styles for subnavigation menus.
-  .subnav-menu-main {
+  #{$selector-subnavigation} {
     transition: all $transition-duration $transition-timing;
   }
 
-  // Modify mobile navigation menu styles.
-  &.-mobile {
+  // Define styles for the main navigation menu's navigation.
+  &-nav {
 
-    // Add separator to toggles.
-    #{$selector}-toggles {
+    // Identify navigation selector.
+    $selector-navigation: &;
+
+    // Define styles for the main navigation menu's navigation toggles.
+    &-toggles {
+      background-color: $background;
       border-bottom: $separator-thickness solid $separator-color;
     }
 
-    // Add background styles for mobile navigation menus.
-    #{$selector}-menu {
-      background-color: $mobile;
+    // Define styles for the main navigation menu's navigation menu.
+    &-menu {
+      transition: all $transition-duration $transition-timing;
+      background-color: $menu;
     }
 
   }

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_skin.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_skin.scss
@@ -1,0 +1,87 @@
+////
+/// @group emory-libraries.patterns.compounds.nav-menu-main
+////
+
+/// Defines the base skin of the nav-menu-main component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @type map
+$compounds-nav-menu-main: (
+
+  'background': color('white'),
+  'mobile': color('blue', 'dark'),
+
+  'separator': (
+    'thickness': $border-width-s,
+    'color': rgba(color('blue', 'dark'), .1)
+  ),
+
+  'transition': (
+    'duration': $transition-duration,
+    'timing': $transition-timing
+  )
+
+);
+
+/// Defines the nav-menu-main component theme.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {map} skin - The component's skin
+///
+/// @output The nav-menu-main component's themeable properties
+@mixin compounds-nav-menu-main--theme ( $skin ) {
+
+  // Capture selector.
+  $selector: &;
+
+  // Capture themeable variables from skin.
+  $background: map-deep-get($skin, 'background');
+  $mobile: map-deep-get($skin, 'mobile');
+
+  // Get transition-specific variables.
+  $transition-duration: map-deep-get($skin, 'transition.duration');
+  $transition-timing: map-deep-get($skin, 'transition.timing');
+
+  // Get separator-specific variables.
+  $separator-thickness: map-deep-get($skin, 'separator.thickness');
+  $separator-color: map-deep-get($skin, 'separator.color');
+
+  // Defines the nav-menu-main component's base styles.
+  // ...
+
+  // Apply background styles.
+  &,
+  &-toggles {
+    background-color: $background;
+  }
+
+  // Define styles for mobile navigation menu.
+  &-menu {
+    transition: all $transition-duration $transition-timing;
+  }
+
+  // Override styles for subnavigation menus.
+  .subnav-menu-main {
+    transition: all $transition-duration $transition-timing;
+  }
+
+  // Modify mobile navigation menu styles.
+  &.-mobile {
+
+    // Add separator to toggles.
+    #{$selector}-toggles {
+      border-bottom: $separator-thickness solid $separator-color;
+    }
+
+    // Add background styles for mobile navigation menus.
+    #{$selector}-menu {
+      background-color: $mobile;
+    }
+
+  }
+
+}

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
@@ -95,7 +95,7 @@
           // Show the mobile navigation menu when toggled.
           ~ #{$selector-navigation}-menu {
             height: 100vh;
-            padding-top: 40px;
+            margin-top: 40px;
             opacity: 1;
             overflow: visible;
             transform: scaley(1);
@@ -129,7 +129,7 @@
           // Hide the mobile navigation menu when not toggled.
           ~ #{$selector-navigation}-menu {
             height: 0;
-            padding-top: 0;
+            margin-top: 0;
             opacity: 0;
             overflow: hidden;
             transform: scaley(0);

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
@@ -1,0 +1,289 @@
+////
+/// @group emory-libraries.patterns.compounds.nav-menu-main
+////
+
+/// Defines the base structure of the nav-menu-main component.
+///
+/// @since 1.0.0-dev.0
+%compounds-nav-menu-main {
+
+  // Capture selector.
+  $selector: &;
+
+  // Define a maximum number of menu items that are allowed.
+  $max-items: 10;
+
+  // Builds the nav-menu-main structure.
+  flex-wrap: nowrap;
+
+  // Group buttons and subnavigation menus together.
+  &-group {
+    display: block;
+  }
+
+  // Override the structure of subnavigation menus.
+  .subnav-menu-main {
+    position: absolute;
+    z-index: z('above');
+  }
+
+  // Always hide subnavigation menu toggles.
+  .input.-toggle {
+    display: none;
+  }
+
+  // Configure mobile navigation menu structure.
+  &.-mobile {
+
+    // Enable mobile navigation on smaller screens.
+    @include breakpoint-s-m {
+
+      // Initialize toggle group structure.
+      #{$selector}-toggles {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+        width: 100%;
+        z-index: (z('above') + 1);
+      }
+
+      // Build the mobile navigation menu structure.
+      #{$selector}-menu {
+        display: flex;
+        flex-direction: column;
+        @include absolute(0);
+        width: 100vw;
+        height: 0;
+        padding-top: 0;
+        opacity: 0;
+        overflow: hidden;
+        transform: scaley(0);
+        transform-origin: top center;
+
+        // Build main mobile navigation menu area.
+        &-area {
+          display: flex;
+          flex-direction: column;
+          flex-grow: 1;
+
+          // Set the default state for subnavigation menus.
+          .subnav-menu-main {
+            @include absolute(0 0 0 100vw);
+            z-index: z('above');
+            overflow: auto;
+          }
+
+          // Register the allowed number of menu items.
+          @for $i from 1 through $max-items {
+
+            // Enable toggling of subnavigation menus.
+            .input.-toggle:nth-of-type(#{$i}) {
+
+              // Show subnavigation menus when toggled.
+              &:checked ~  .subnav-menu-main:nth-of-type(#{$i}) {
+                left: 0;
+              }
+
+              // Hide subnavigation menus when not toggled.
+              &:not(:checked) ~ .subnav-menu-main:nth-of-type(#{$i}) {
+                left: 100vw;
+              }
+
+            }
+
+          }
+
+        }
+
+      }
+
+      // Enable toggling of the mobile navigation menu.
+      > .input.-toggle {
+
+        // Configure mobile navigation menu structure when toggled.
+        &:checked {
+
+          // Show the mobile navigation menu when toggled.
+          ~ #{$selector}-menu {
+            height: 100vh;
+            padding-top: 40px;
+            opacity: 1;
+            overflow: visible;
+            transform: scaley(1);
+          }
+
+          // Configure the mobile navigation menu toggles.
+          ~ #{$selector}-toggles .nav-button.-toggle {
+
+            // Hide the open button.
+            &.-open {
+              display: none;
+            }
+
+            // Show the close button.
+            &.-close {
+              display: flex;
+            }
+
+          }
+
+        }
+
+        // Configure mobile navigation menu structure when not toggled.
+        &:not(:checked) {
+
+          // Hide the mobile navigation menu when not toggled.
+          ~ #{$selector}-menu {
+            height: 0;
+            padding-top: 0;
+            opacity: 0;
+            overflow: hidden;
+            transform: scaley(0);
+          }
+
+          // Configure the mobile navigation menu toggles.
+          ~ #{$selector}-toggles .nav-button.-toggle {
+
+            // Show the open button.
+            &.-open {
+              display: flex;
+            }
+
+            // Hide the close button.
+            &.-close {
+              display: none;
+            }
+
+          }
+
+        }
+
+      }
+
+    };
+
+    // Disable mobile navigation on larger screens.
+    @include breakpoint-l-xl {
+      display: none;
+    };
+
+  }
+
+  // Configure tablet navigation menu structure.
+  &.-tablet {
+
+    // Disable tablet navitation on smaller screens.
+    @include breakpoint-s-m {
+      display: none;
+    };
+
+    // Enable tablet navigation on larger screens.
+    @include breakpoint-l {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      align-items: center;
+      width: max-content;
+      margin-left: auto;
+
+      // Set the default state for subnavigation menus.
+      .subnav-menu-main {
+        top: 100%;
+        right: 0;
+        opacity: 0;
+        max-height: 0;
+        transform: scaley(0);
+        overflow: hidden;
+        transform-origin: top right;
+      }
+
+      // Register the allowed number of menu items.
+      @for $i from 1 through $max-items {
+
+        // Enable toggling of subnavigation menus.
+        .input.-toggle:nth-of-type(#{$i}) {
+
+          // Show subnavigation menus when toggled.
+          &:checked ~ .subnav-menu-main:nth-of-type(#{$i}) {
+            overflow: visible;
+            opacity: 1;
+            max-height: 5000px;
+            transform: scaley(1);
+          }
+
+          // Hide subnavigation menus when not toggled.
+          &:not(:checked) ~ .subnav-menu-main:nth-of-type(#{$i}) {
+            overflow: hidden;
+            opacity: 0;
+            max-height: 0;
+            transform: scaley(0);
+          }
+
+        }
+
+      }
+
+    };
+
+    // Disable tablet navigation on huge screens.
+    @include breakpoint-xl {
+      display: none;
+    };
+
+  }
+
+  // Configure desktop navigation menu structure.
+  &.-desktop {
+
+    // Disable desktop navigation on smaller screens.
+    @include breakpoint-s-m-l {
+      display: none;
+    };
+
+    // Enable desktop navigation on huge screens.
+    @include breakpoint-xl {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      align-items: center;
+      width: max-content;
+      margin-left: auto;
+
+      // Set the default state for subnavigation menus.
+      .subnav-menu-main {
+        top: 100%;
+        right: 0;
+        opacity: 0;
+        max-height: 0;
+        transform: scaley(0);
+        overflow: hidden;
+        transform-origin: top right;
+      }
+
+      // Enable toggling of subnavigation menus.
+      .input.-toggle {
+
+        // Show subnavigation menus when toggled.
+        &:checked ~ .subnav-menu-main {
+          overflow: visible;
+          opacity: 1;
+          max-height: 5000px;
+          transform: scaley(1);
+        }
+
+        // Hide subnavigation menus when not toggled.
+        &:not(:checked) ~ .subnav-menu-main {
+          overflow: hidden;
+          opacity: 0;
+          max-height: 0;
+          transform: scaley(0);
+        }
+
+      }
+
+    };
+
+  }
+
+}

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
@@ -231,12 +231,17 @@
       // Configure toggles based on their index.
       &:nth-of-type(#{$i}) {
 
-        // Identify navigation and subnavigation selectors.
+        // Identify necessary selectors.
         $selector-navigation: unquote('#{$selector}-nav');
         $selector-subnavigation: (
           'desktop': unquote('#{$selector-navigation}-group:nth-of-type(#{$i}) .subnav-menu-main'),
           'tablet': unquote('.subnav-menu-main:nth-of-type(#{$i})'),
           'mobile': unquote('#{$selector-navigation}-menu #{$selector-navigation}-menu-area .subnav-menu-main:nth-of-type(#{$i})')
+        );
+        $selector-button: (
+          'desktop': unquote('#{$selector-navigation}-group:nth-of-type(#{$i}) .nav-button'),
+          'tablet': unquote('.nav-button:nth-of-type(#{$i})'),
+          'mobile': unquote('#{$selector-navigation}-menu #{$selector-navigation}-menu-area .nav-button:nth-of-type(#{$i})')
         );
 
         // Show subnavigation menus when toggled.
@@ -256,6 +261,12 @@
                 transform: scaley(1);
               }
 
+              // Add toggled styles to the navigation button.
+              #{map-get($selector-button, 'desktop')} {
+                @include atoms-nav-button--state--structure('focus', $selector: false);
+                @include atoms-nav-button--state('focus', $selector: false);
+              }
+
             }
 
             // Configure tablet navigation toggles.
@@ -267,6 +278,12 @@
                 opacity: 1;
                 max-height: 5000px;
                 transform: scaley(1);
+              }
+
+              // Add toggled styles to the navigation button.
+              #{map-get($selector-button, 'tablet')} {
+                @include atoms-nav-button--state--structure('focus', $selector: false);
+                @include atoms-nav-button--state('focus', $selector: false);
               }
 
             }

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
@@ -102,16 +102,21 @@
           }
 
           // Configure the mobile navigation menu toggles.
-          ~ #{$selector-navigation}-toggles #{$selector-mobile-toggle} {
+          ~ #{$selector-navigation}-toggles {
 
-            // Hide the open button.
-            &.-open {
-              display: none;
-            }
+            // Manipulate mobile menu toggles.
+            #{$selector-mobile-toggle} {
 
-            // Show the close button.
-            &.-close {
-              display: flex;
+              // Hide the open button.
+              &.-open {
+                display: none;
+              }
+
+              // Show the close button.
+              &.-close {
+                display: flex;
+              }
+
             }
 
           }
@@ -131,16 +136,21 @@
           }
 
           // Configure the mobile navigation menu toggles.
-          ~ #{$selector-navigation}-toggles #{$selector-mobile-toggle} {
+          ~ #{$selector-navigation}-toggles {
 
-            // Show the open button.
-            &.-open {
-              display: flex;
-            }
+            // Manipulate mobile menu toggles.
+            #{$selector-mobile-toggle} {
 
-            // Hide the close button.
-            &.-close {
-              display: none;
+              // Show the open button.
+              &.-open {
+                display: flex;
+              }
+
+              // Hide the close button.
+              &.-close {
+                display: none;
+              }
+
             }
 
           }

--- a/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/nav-menu-main/_structure.scss
@@ -7,39 +7,47 @@
 /// @since 1.0.0-dev.0
 %compounds-nav-menu-main {
 
-  // Capture selector.
+  // Capture selectors.
   $selector: &;
+  $selector-toggle: unquote('.input.-toggle');
+  $selector-subnavigation: unquote('.subnav-menu-main');
 
-  // Define a maximum number of menu items that are allowed.
+  // Set the maximum number of items allowed within the main navigation menu.
   $max-items: 10;
 
   // Builds the nav-menu-main structure.
   flex-wrap: nowrap;
 
-  // Group buttons and subnavigation menus together.
-  &-group {
-    display: block;
-  }
-
   // Override the structure of subnavigation menus.
-  .subnav-menu-main {
+  #{$selector-subnavigation} {
     position: absolute;
     z-index: z('above');
   }
 
   // Always hide subnavigation menu toggles.
-  .input.-toggle {
+  #{$selector-toggle} {
     display: none;
   }
 
-  // Configure mobile navigation menu structure.
-  &.-mobile {
+  // Builds the navigation structure.
+  &-nav {
 
-    // Enable mobile navigation on smaller screens.
-    @include breakpoint-s-m {
+    // Identify navigation selector.
+    $selector-navigation: &;
+
+    // Group buttons and subnavigation menus together.
+    &-group {
+      display: block;
+    }
+
+    // Configure mobile navigation menu structure.
+    &.-mobile {
+
+      // Identify selector for mobile navigation toggles.
+      $selector-mobile-toggle: unquote('.nav-button.-toggle');
 
       // Initialize toggle group structure.
-      #{$selector}-toggles {
+      #{$selector-navigation}-toggles {
         display: flex;
         flex-direction: row;
         justify-content: flex-start;
@@ -49,7 +57,7 @@
       }
 
       // Build the mobile navigation menu structure.
-      #{$selector}-menu {
+      #{$selector-navigation}-menu {
         display: flex;
         flex-direction: column;
         @include absolute(0);
@@ -68,30 +76,10 @@
           flex-grow: 1;
 
           // Set the default state for subnavigation menus.
-          .subnav-menu-main {
+          #{$selector-subnavigation} {
             @include absolute(0 0 0 100vw);
             z-index: z('above');
             overflow: auto;
-          }
-
-          // Register the allowed number of menu items.
-          @for $i from 1 through $max-items {
-
-            // Enable toggling of subnavigation menus.
-            .input.-toggle:nth-of-type(#{$i}) {
-
-              // Show subnavigation menus when toggled.
-              &:checked ~  .subnav-menu-main:nth-of-type(#{$i}) {
-                left: 0;
-              }
-
-              // Hide subnavigation menus when not toggled.
-              &:not(:checked) ~ .subnav-menu-main:nth-of-type(#{$i}) {
-                left: 100vw;
-              }
-
-            }
-
           }
 
         }
@@ -99,13 +87,13 @@
       }
 
       // Enable toggling of the mobile navigation menu.
-      > .input.-toggle {
+      > #{$selector-toggle} {
 
         // Configure mobile navigation menu structure when toggled.
         &:checked {
 
           // Show the mobile navigation menu when toggled.
-          ~ #{$selector}-menu {
+          ~ #{$selector-navigation}-menu {
             height: 100vh;
             padding-top: 40px;
             opacity: 1;
@@ -114,7 +102,7 @@
           }
 
           // Configure the mobile navigation menu toggles.
-          ~ #{$selector}-toggles .nav-button.-toggle {
+          ~ #{$selector-navigation}-toggles #{$selector-mobile-toggle} {
 
             // Hide the open button.
             &.-open {
@@ -134,7 +122,7 @@
         &:not(:checked) {
 
           // Hide the mobile navigation menu when not toggled.
-          ~ #{$selector}-menu {
+          ~ #{$selector-navigation}-menu {
             height: 0;
             padding-top: 0;
             opacity: 0;
@@ -143,7 +131,7 @@
           }
 
           // Configure the mobile navigation menu toggles.
-          ~ #{$selector}-toggles .nav-button.-toggle {
+          ~ #{$selector-navigation}-toggles #{$selector-mobile-toggle} {
 
             // Show the open button.
             &.-open {
@@ -161,25 +149,15 @@
 
       }
 
-    };
+      // Disable mobile navigation on larger screens.
+      @include breakpoint-l-xl {
+        display: none;
+      };
 
-    // Disable mobile navigation on larger screens.
-    @include breakpoint-l-xl {
-      display: none;
-    };
+    }
 
-  }
-
-  // Configure tablet navigation menu structure.
-  &.-tablet {
-
-    // Disable tablet navitation on smaller screens.
-    @include breakpoint-s-m {
-      display: none;
-    };
-
-    // Enable tablet navigation on larger screens.
-    @include breakpoint-l {
+    // Configure tablet navigation menu structure.
+    &.-tablet {
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
@@ -188,7 +166,7 @@
       margin-left: auto;
 
       // Set the default state for subnavigation menus.
-      .subnav-menu-main {
+      #{$selector-subnavigation} {
         top: 100%;
         right: 0;
         opacity: 0;
@@ -198,91 +176,164 @@
         transform-origin: top right;
       }
 
-      // Register the allowed number of menu items.
-      @for $i from 1 through $max-items {
+      // Disable tablet navitation on smaller screens.
+      @include breakpoint-s-m {
+        display: none;
+      };
 
-        // Enable toggling of subnavigation menus.
-        .input.-toggle:nth-of-type(#{$i}) {
+      // Disable tablet navigation on huge screens.
+      @include breakpoint-xl {
+        display: none;
+      };
 
-          // Show subnavigation menus when toggled.
-          &:checked ~ .subnav-menu-main:nth-of-type(#{$i}) {
-            overflow: visible;
-            opacity: 1;
-            max-height: 5000px;
-            transform: scaley(1);
-          }
+    }
 
-          // Hide subnavigation menus when not toggled.
-          &:not(:checked) ~ .subnav-menu-main:nth-of-type(#{$i}) {
-            overflow: hidden;
-            opacity: 0;
-            max-height: 0;
-            transform: scaley(0);
-          }
+    // Configure desktop navigation menu structure.
+    &.-desktop {
 
-        }
+      // Disable desktop navigation on smaller screens.
+      @include breakpoint-s-m-l {
+        display: none;
+      };
 
-      }
+      // Enable desktop navigation on huge screens.
+      @include breakpoint-xl {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+        width: max-content;
+        margin-left: auto;
 
-    };
-
-    // Disable tablet navigation on huge screens.
-    @include breakpoint-xl {
-      display: none;
-    };
-
-  }
-
-  // Configure desktop navigation menu structure.
-  &.-desktop {
-
-    // Disable desktop navigation on smaller screens.
-    @include breakpoint-s-m-l {
-      display: none;
-    };
-
-    // Enable desktop navigation on huge screens.
-    @include breakpoint-xl {
-      display: flex;
-      flex-direction: row;
-      justify-content: flex-end;
-      align-items: center;
-      width: max-content;
-      margin-left: auto;
-
-      // Set the default state for subnavigation menus.
-      .subnav-menu-main {
-        top: 100%;
-        right: 0;
-        opacity: 0;
-        max-height: 0;
-        transform: scaley(0);
-        overflow: hidden;
-        transform-origin: top right;
-      }
-
-      // Enable toggling of subnavigation menus.
-      .input.-toggle {
-
-        // Show subnavigation menus when toggled.
-        &:checked ~ .subnav-menu-main {
-          overflow: visible;
-          opacity: 1;
-          max-height: 5000px;
-          transform: scaley(1);
-        }
-
-        // Hide subnavigation menus when not toggled.
-        &:not(:checked) ~ .subnav-menu-main {
-          overflow: hidden;
+        // Set the default state for subnavigation menus.
+        #{$selector-subnavigation} {
+          top: 100%;
+          right: 0;
           opacity: 0;
           max-height: 0;
           transform: scaley(0);
+          overflow: hidden;
+          transform-origin: top right;
+        }
+
+      };
+
+    }
+
+  }
+
+  // Configure navigation menu toggles.
+  > #{$selector-toggle} {
+
+    // Only configure up to the maximum number of items allowed within the navigation menu.
+    @for $i from 1 through $max-items {
+
+      // Configure toggles based on their index.
+      &:nth-of-type(#{$i}) {
+
+        // Identify navigation and subnavigation selectors.
+        $selector-navigation: unquote('#{$selector}-nav');
+        $selector-subnavigation: (
+          'desktop': unquote('#{$selector-navigation}-group:nth-of-type(#{$i}) .subnav-menu-main'),
+          'tablet': unquote('.subnav-menu-main:nth-of-type(#{$i})'),
+          'mobile': unquote('#{$selector-navigation}-menu #{$selector-navigation}-menu-area .subnav-menu-main:nth-of-type(#{$i})')
+        );
+
+        // Show subnavigation menus when toggled.
+        &:checked {
+
+          // Manipulate all navigation menus at the same time.
+          ~ #{$selector-navigation} {
+
+            // Configure desktop navigation toggles.
+            &.-desktop {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'desktop')} {
+                overflow: visible;
+                opacity: 1;
+                max-height: 5000px;
+                transform: scaley(1);
+              }
+
+            }
+
+            // Configure tablet navigation toggles.
+            &.-tablet {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'tablet')} {
+                overflow: visible;
+                opacity: 1;
+                max-height: 5000px;
+                transform: scaley(1);
+              }
+
+            }
+
+            // Configure mobile navigation toggles.
+            &.-mobile {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'mobile')} {
+                left: 0;
+              }
+
+            }
+
+          }
+
+        }
+
+        // Hide subnavigation menus when not toggled.
+        &:not(:checked) {
+
+          // Manipulate all navigation menus at the same time.
+          ~ #{$selector-navigation} {
+
+            // Configure desktop navigation toggles.
+            &.-desktop {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'desktop')} {
+                overflow: hidden;
+                opacity: 0;
+                max-height: 0;
+                transform: scaley(0);
+              }
+
+            }
+
+            // Configure tablet navigation toggles.
+            &.-tablet {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'tablet')} {
+                overflow: hidden;
+                opacity: 0;
+                max-height: 0;
+                transform: scaley(0);
+              }
+
+            }
+
+            // Configure mobile navigation toggles.
+            &.-mobile {
+
+              // Toggle the subnavigation menu.
+              #{map-get($selector-subnavigation, 'mobile')} {
+                left: 100vw;
+              }
+
+            }
+
+          }
+
         }
 
       }
 
-    };
+    }
 
   }
 

--- a/scss/emory-libraries/patterns/40-compounds/subnav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/subnav-menu-main/_structure.scss
@@ -7,12 +7,16 @@
 /// @since 1.0.0-dev.0
 %compounds-subnav-menu-main {
 
+  // Set menu padding.
+  $padding: 25px;
+
   // Builds the subnav-menu-main structure.
   display: flex;
   flex-direction: column;
 
   // Adjust the subnav menu structure on large screens.
   @include breakpoint-l {
+    @include padding-y($padding);
     width: 100vw;
   };
 
@@ -56,6 +60,11 @@
       }
       > *.-span {
         grid-column: 1 / span 4 !important;
+
+        &:last-child {
+          margin-bottom: -$padding;
+        }
+
       }
 
     };
@@ -68,7 +77,13 @@
   }
 
   // Modifies structure for categorized subnav menus.
-  &.-categorized {}
+  &.-categorized {
+
+    > *:last-child {
+      margin-bottom: 0;
+    }
+
+  }
 
   // Builds the subnav menu main heading structure.
   &-heading {

--- a/scss/emory-libraries/patterns/40-compounds/subnav-menu-main/_structure.scss
+++ b/scss/emory-libraries/patterns/40-compounds/subnav-menu-main/_structure.scss
@@ -6,36 +6,45 @@
 ///
 /// @since 1.0.0-dev.0
 %compounds-subnav-menu-main {
-  
+
   // Builds the subnav-menu-main structure.
   display: flex;
   flex-direction: column;
-  
-  // Adjust the subnav menu strcture on large screens.
+
+  // Adjust the subnav menu structure on large screens.
   @include breakpoint-l {
-    width: 690px;
+    width: 100vw;
   };
-  
+
+  // Adjust the subnav menu structure on extra large screens.
+  @include breakpoint-xl {
+    width: 350px;
+
+    &.has-resources {
+      width: 690px;
+    }
+
+  };
+
   // Modifies structure for grouped subnav menus.
   &.-grouped {
     display: grid;
     grid-template-columns: 1fr;
-    
+
     // Modifies structure on large screens.
     @include breakpoint-l {
       grid-template-columns: $rhythm-x [left-start] 1fr [left-end right-start] 1fr [right-end] $rhythm-x;
-      width: 730px;
-      
+
       > *:nth-child(odd) {
-        grid-column: left; 
+        grid-column: left;
       }
       > *:nth-child(even) {
         grid-column: right;
       }
-      
+
       &.has-search {
         > *:nth-child(odd) {
-          grid-column: right; 
+          grid-column: right;
         }
         > *:nth-child(even) {
           grid-column: left;
@@ -48,30 +57,28 @@
       > *.-span {
         grid-column: 1 / span 4 !important;
       }
-      
+
     };
-    
+
+    // Modifies structure on extra large screens.
+    @include breakpoint-xl {
+      width: 730px;
+    };
+
   }
-  
+
   // Modifies structure for categorized subnav menus.
-  &.-categorized {
-    
-    // Modifies structure on large screens.
-    @include breakpoint-l {
-      width: 350px;
-    };
-    
-  }
-  
+  &.-categorized {}
+
   // Builds the subnav menu main heading structure.
   &-heading {
     display: block;
-  
+
     // Only show the heading when the subnav menu is in mobile mode.
     @include breakpoint-l {
       display: none;
     };
-    
+
   }
-  
+
 }

--- a/scss/emory-libraries/patterns/50-organisms/_nav-bar-main.scss
+++ b/scss/emory-libraries/patterns/50-organisms/_nav-bar-main.scss
@@ -1,0 +1,39 @@
+////
+/// @group emory-libraries.patterns.organisms.nav-bar-main
+////
+
+/// Load the nav-bar-main component's structure and skin.
+@import 'nav-bar-main/structure';
+@import 'nav-bar-main/skin';
+
+/// Builds a constructor for the nav-bar-main component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {placeholder} organisms-nav-bar-main
+/// @requires {variable} organisms-nav-bar-main
+/// @requires {mixin} organisms-nav-bar-main--theme
+/// @requires {function} Brandy::map-extend <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-extend>
+///
+/// @param {map} $custom - A custom skin for the component
+///
+/// @output The native structure and skin of our nav-bar-main component
+///
+/// @status construction
+@mixin organisms-nav-bar-main ( $custom: () ) {
+  
+  // Extend the default skin.
+  $skin: map-extend($organisms-nav-bar-main, $custom);
+  
+  // Initialize the nav-bar-main component.
+  & {
+    
+    // Load structure.
+    @extend %organisms-nav-bar-main;
+    
+    // Load skins.
+    @include organisms-nav-bar-main--theme( $skin );
+    
+  }
+  
+}

--- a/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_skin.scss
+++ b/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_skin.scss
@@ -1,0 +1,33 @@
+////
+/// @group emory-libraries.patterns.organisms.nav-bar-main
+////
+
+/// Defines the base skin of the nav-bar-main component.
+///
+/// @since 1.0.0-dev.0
+///
+/// @type map
+$organisms-nav-bar-main: (
+  
+  
+  
+);
+
+/// Defines the nav-bar-main component theme.
+///
+/// @since 1.0.0-dev.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {map} skin - The component's skin
+///
+/// @output The nav-bar-main component's themeable properties
+@mixin organisms-nav-bar-main--theme ( $skin ) {
+  
+  // Capture themeable variables from skin.
+  // ...
+  
+  // Defines the nav-bar-main component's base styles.
+  // ...
+  
+}

--- a/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_skin.scss
+++ b/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_skin.scss
@@ -8,9 +8,16 @@
 ///
 /// @type map
 $organisms-nav-bar-main: (
-  
-  
-  
+
+  'background': color('white'),
+  'padding': (
+    's': 10px,
+    'm': 10px,
+    'l': 20px,
+    'xl': 30px
+  ),
+  'spacing': 25px
+
 );
 
 /// Defines the nav-bar-main component theme.
@@ -23,11 +30,74 @@ $organisms-nav-bar-main: (
 ///
 /// @output The nav-bar-main component's themeable properties
 @mixin organisms-nav-bar-main--theme ( $skin ) {
-  
+
+  // Identify selectors.
+  $selector-branding: unquote('.branding-header');
+  $selector-navigation: unquote('.nav-menu-main');
+
   // Capture themeable variables from skin.
-  // ...
-  
+  $background: map-deep-get($skin, 'background');
+  $padding: map-deep-get($skin, 'padding');
+  $spacing: map-deep-get($skin, 'spacing');
+
+  // Apply padding to navigation bars across various screen sizes.
+  @each $breakpoint, $pad in $padding {
+    @include breakpoint( screen($breakpoint) ) {
+      @include padding-x($pad);
+    };
+  }
+
   // Defines the nav-bar-main component's base styles.
-  // ...
-  
+  grid-column-gap: $spacing;
+  background-color: $background;
+
+  // Override navigation styles.
+  #{$selector-navigation} {
+
+    // Identify selectors.
+    $selector-navigation-container: unquote('#{$selector-navigation}-nav');
+    $selector-navigation-subnavigation: unquote('.subnav-menu-main');
+
+    // Adjust the navigation menu container's structure.
+    #{$selector-navigation-container} {
+
+      // Fix the placement of subnavigation menus for mobile navigation.
+      &.-mobile {
+
+        // Adjust the navigation menu.
+        #{$selector-navigation-container}-menu {
+
+          // Fix alignment of the navigation menus.
+          @each $breakpoint, $pad in $padding {
+            @include breakpoint( screen($breakpoint) ) {
+              right: -$pad;
+              left: -$pad;
+            };
+          }
+
+        }
+
+      }
+
+      // Fix the placement of subnavigation menus for tablet navigation.
+      &.-tablet {
+
+        // Adjust the subnavigation menu.
+        #{$selector-navigation-subnavigation} {
+
+          // Fix right-alignment of subnavigation menus.
+          @each $breakpoint, $pad in $padding {
+            @include breakpoint( screen($breakpoint) ) {
+              right: -$pad;
+            };
+          }
+
+        }
+
+      }
+
+    }
+
+  }
+
 }

--- a/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_structure.scss
+++ b/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_structure.scss
@@ -1,0 +1,13 @@
+////
+/// @group emory-libraries.patterns.organisms.nav-bar-main
+////
+
+/// Defines the base structure of the nav-bar-main component.
+///
+/// @since 1.0.0-dev.0
+%organisms-nav-bar-main {
+  
+  // Builds the nav-bar-main structure.
+  // ...
+  
+}

--- a/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_structure.scss
+++ b/scss/emory-libraries/patterns/50-organisms/nav-bar-main/_structure.scss
@@ -6,8 +6,70 @@
 ///
 /// @since 1.0.0-dev.0
 %organisms-nav-bar-main {
-  
+
+  // Identify selectors.
+  $selector-branding: unquote('.branding-header');
+  $selector-navigation: unquote('.nav-menu-main');
+
   // Builds the nav-bar-main structure.
-  // ...
-  
+  display: grid;
+  grid-template-areas: "navigation"
+                       "branding";
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(2, min-content);
+
+  // Adjust navigation bar structure on larger screens.
+  @include breakpoint-l-xl {
+    grid-template-areas: "branding navigation";
+    grid-template-columns: min-content 1fr;
+    grid-template-rows: min-content;
+  };
+
+  // Override branding and navigation structure.
+  #{$selector-branding},
+  #{$selector-navigation} {
+    @include padding-x(0);
+    @include margin-x(0);
+  }
+
+  // Override branding structure.
+  #{$selector-branding} {
+    grid-area: branding;
+
+    @include breakpoint-l {
+      z-index: z('above') + 1;
+    };
+
+  }
+
+  // Override navigation structure.
+  #{$selector-navigation} {
+    grid-area: navigation;
+
+    @include breakpoint-s {
+      z-index: z('above') + 1;
+    };
+
+    // Identify selectors.
+    $selector-navigation-container: unquote('#{$selector-navigation}-nav');
+    $selector-navigation-button: unquote('.nav-button');
+
+    // Adjust the navigation menu's structure.
+    #{$selector-navigation-container} {
+      height: 100% !important;
+
+      // Adjust the tablet navigation menu structure.
+      &.-tablet {
+
+        // Force navigation button's to be full-height.
+        #{$selector-navigation-button} {
+          height: 100% !important;
+        }
+
+      }
+
+    }
+
+  }
+
 }

--- a/scss/emory-libraries/patterns/__master.scss
+++ b/scss/emory-libraries/patterns/__master.scss
@@ -90,6 +90,7 @@
 @import '40-compounds/popular-links-menu';
 @import '40-compounds/subnav-menu-main';
 @import '40-compounds/slider';
+@import '40-compounds/nav-menu-main';
 /*** INSERT NEW COMPOUNDS HERE ***/
 
 

--- a/scss/emory-libraries/patterns/__master.scss
+++ b/scss/emory-libraries/patterns/__master.scss
@@ -104,6 +104,7 @@
 @import '50-organisms/section-deep-dive';
 @import '50-organisms/flow-content-boxes';
 @import '50-organisms/intro-interior-cover';
+@import '50-organisms/nav-bar-main';
 /*** INSERT NEW ORGANISMS HERE ***/
 
 

--- a/scss/emory-libraries/utils/mixins/_breakpoints.scss
+++ b/scss/emory-libraries/utils/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 ////
 
 /// Build multiple media queries for multiple breakpoints at the same time.
-/// 
+///
 /// @since 1.0.0
 ///
 /// @requires {mixin} Breakpoint::breakpoint <http://breakpoint-sass.com/>
@@ -12,149 +12,166 @@
 ///
 /// @content
 @mixin breakpoints( $breakpoints... ) {
-  
+
   @each $breakpoint in $breakpoints {
-    
-    @include breakpoint($breakpoint) { 
+
+    @include breakpoint($breakpoint) {
       @content;
     };
-    
+
   }
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for small screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} Breakpoint::breakpoint <http://breakpoint-sass.com/>
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-s {
-    
-  @include breakpoint(screen('s')) { 
+
+  @include breakpoint(screen('s')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for medium screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} Breakpoint::breakpoint <http://breakpoint-sass.com/>
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-m {
-    
-  @include breakpoint(screen('m')) { 
+
+  @include breakpoint(screen('m')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for large screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} Breakpoint::breakpoint <http://breakpoint-sass.com/>
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-l {
-    
-  @include breakpoint(screen('l')) { 
+
+  @include breakpoint(screen('l')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for extra-large screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} Breakpoint::breakpoint <http://breakpoint-sass.com/>
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-xl {
-    
-  @include breakpoint(screen('xl')) { 
+
+  @include breakpoint(screen('xl')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for small and medium screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} breakpoints
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-s-m {
-    
-  @include breakpoints(screen('s'), screen('m')) { 
+
+  @include breakpoints(screen('s'), screen('m')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for small, medium, and large screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} breakpoints
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-s-m-l {
-    
-  @include breakpoints(screen('s'), screen('m'), screen('l')) { 
+
+  @include breakpoints(screen('s'), screen('m'), screen('l')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for medium and large screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} breakpoints
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-m-l {
-    
-  @include breakpoints(screen('m'), screen('l')) { 
+
+  @include breakpoints(screen('m'), screen('l')) {
     @content;
   };
-  
+
 }
 
 /// A breakpoint shorthand to create a media query for medium, large, and extra-large screens.
-/// 
+///
 /// @since 1.0.0
 ///
-/// @requires {variable} screens 
+/// @requires {variable} screens
 /// @requires {mixin} breakpoints
 /// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
 ///
 /// @content
 @mixin breakpoint-m-l-xl {
-    
-  @include breakpoints(screen('m'), screen('l'), screen('xl')) { 
+
+  @include breakpoints(screen('m'), screen('l'), screen('xl')) {
     @content;
   };
-  
+
+}
+
+/// A breakpoint shorthand to create a media query for large and extra large screens.
+///
+/// @since 1.0.0
+///
+/// @requires {variable} screens
+/// @requires {mixin} breakpoints
+/// @requires {function} Brandy::screen <https://laurenhamel.github.io/brandy/docs/#brandy-getters-function-screen>
+///
+/// @content
+@mixin breakpoint-l-xl {
+
+  @include breakpoints(screen('l'), screen('xl')) {
+    @content;
+  };
+
 }

--- a/test/comps-compounds.html
+++ b/test/comps-compounds.html
@@ -382,7 +382,7 @@
 
       <p class="tile-utility-description">This section covers the &quot;Woodruff Library Collection Management Policy&quot;, as well as departmental, or subject, policies; which outline our efforts in building collections to support more than 30 academic programs. View policies by subject area in this section.</p>
     </div>
- </div>
+  </div>
 
   <!-- compounds-utility-list -->
   <div style="display: flex; flex-direction: column;">

--- a/test/comps-compounds.html
+++ b/test/comps-compounds.html
@@ -4,7 +4,7 @@
   <link rel="stylesheet" href="tmp/comps-compounds.css">
 
 </head>
-<body>
+<body style="padding-bottom: 1000px;">
 
   <!-- compounds-nav-menu-utility -->
   <div>
@@ -174,7 +174,6 @@
     </nav>
 
   </div>
-
 
   <!-- conmpounds-popular-links -->
   <div class="popular-links-menu">
@@ -869,7 +868,7 @@
   <div>
 
     <!-- default -->
-    <nav class="subnav-menu-main" style="margin: 25px 0;">
+    <nav class="subnav-menu-main has-resources" style="margin: 25px 0;">
 
       <button class="subnav-button -back">Back to Main Menu</button>
 
@@ -1160,6 +1159,981 @@
         </div>
       </div>
     </div>
+
+  </div>
+
+  <!-- compounds-nav-menu-main -->
+  <div>
+
+    <!-- desktop -->
+    <nav class="nav-menu-main -desktop">
+
+      <div class="nav-menu-main-group">
+        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--materials">
+        <label class="nav-button" for="nav-menu-desktop--materials">Materials</label>
+        <nav class="subnav-menu-main">
+
+          <label class="subnav-button -back" for="nav-menu-desktop--materials">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Materials</span>
+
+          <button class="subnav-button">Books</button>
+          <button class="subnav-button">Films and Videos</button>
+          <button class="subnav-button">Music and Scores</button>
+          <button class="subnav-button">Journals</button>
+          <button class="subnav-button">Databases</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">eBooks and Audiobooks</button>
+          <button class="subnav-button">Research and Library Guides</button>
+          <button class="subnav-button">Theses and Dissertations</button>
+          <button class="subnav-button">Archival and Manuscripts</button>
+          <button class="subnav-button">Faculty Works</button>
+          <button class="subnav-button">Images and Maps</button>
+          <button class="subnav-button">Equipment and Gadgets</button>
+
+        </nav>
+      </div>
+
+      <div class="nav-menu-main-group">
+        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--tools">
+        <label class="nav-button" for="nav-menu-desktop--tools">Tools</label>
+        <nav class="subnav-menu-main has-resources">
+
+          <label class="subnav-button -back" for="nav-menu-desktop--tools">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Tools</span>
+
+          <label class="subnav-button -resource">
+            DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Center for Digital Scholarship
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Ares <span class="subnav-button-alias">(Course Reserves)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+
+        </nav>
+      </div>
+
+      <div class="nav-menu-main-group">
+        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--services">
+        <label class="nav-button" for="nav-menu-desktop--services">Services</label>
+        <nav class="subnav-menu-main -grouped">
+
+          <label class="subnav-button -back" for="nav-menu-desktop--services">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Services</span>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Around the Library</span>
+
+            <button class="subnav-button">Reserve a Study or Presentation Room</button>
+            <button class="subnav-button">Find a Quiet Study Area</button>
+            <button class="subnav-button">Find a Workstation or Application</button>
+            <button class="subnav-button">Print, Copy, and Scan</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Get Assistance</span>
+
+            <button class="subnav-button">Borrow Equipment and Gadgets</button>
+            <button class="subnav-button">Research and Writing Assistance</button>
+            <button class="subnav-button">Access Course Reserves</button>
+            <button class="subnav-button">Request or Recall Materials</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Technology Assistance</span>
+
+            <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+            <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+            <button class="subnav-button">Get Hardware or Software Support</button>
+            <button class="subnav-button">Repair Your Device or Computer</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Make a Request</span>
+
+            <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+            <button class="subnav-button">Request a Purchase</button>
+            <button class="subnav-button">Submit Ask eJournals</button>
+            <button class="subnav-button">Apply for an Individual Study Room</button>
+
+          </div>
+
+          <button class="subnav-button -viewall -span">View All Services</button>
+
+        </nav>
+      </div>
+
+      <div class="nav-menu-main-group">
+        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--research">
+        <label class="nav-button" for="nav-menu-desktop--research">Research</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <label class="subnav-button -back" for="nav-menu-desktop--research">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Research</span>
+
+          <button class="subnav-button">Subject Librarians Directory</button>
+          <button class="subnav-button">Research Data</button>
+          <button class="subnav-button">Award and Research Programs</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help With Research</span>
+
+            <button class="subnav-button">Selecting Research Topics</button>
+            <button class="subnav-button">Finding Source Materials</button>
+            <button class="subnav-button">Evaluating Sources</button>
+            <button class="subnav-button">Citing and Using Sources</button>
+
+          </div>
+
+        </nav>
+      </div>
+
+      <div class="nav-menu-main-group">
+        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--using-the-library">
+        <label class="nav-button" for="nav-menu-desktop--using-the-library">Using the Library</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <label class="subnav-button -back" for="nav-menu-desktop--using-the-library">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Using the Library</span>
+
+          <button class="subnav-button">Borrowing Privileges</button>
+          <button class="subnav-button">InterLibrary Lending (ILL)</button>
+          <button class="subnav-button">Library Maps and Spaces</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">Guest Access</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help Using the Library</span>
+
+            <button class="subnav-button">Search for Specific Items</button>
+            <button class="subnav-button">Questions About Articles</button>
+            <button class="subnav-button">Questions About Books</button>
+            <button class="subnav-button">Printing, Logging In, and Access</button>
+
+          </div>
+
+        </nav>
+      </div>
+
+    </nav>
+
+    <!-- tablet -->
+    <nav class="nav-menu-main -tablet">
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--materials">
+      <label class="nav-button" for="nav-menu-tablet--materials">Materials</label>
+      <nav class="subnav-menu-main">
+
+        <label class="subnav-button -back" for="nav-menu-tablet--materials">Back to Main Menu</label>
+
+        <span class="subnav-menu-main-heading">Materials</span>
+
+        <button class="subnav-button">Books</button>
+        <button class="subnav-button">Films and Videos</button>
+        <button class="subnav-button">Music and Scores</button>
+        <button class="subnav-button">Journals</button>
+        <button class="subnav-button">Databases</button>
+        <button class="subnav-button">Course Reserves</button>
+        <button class="subnav-button">eBooks and Audiobooks</button>
+        <button class="subnav-button">Research and Library Guides</button>
+        <button class="subnav-button">Theses and Dissertations</button>
+        <button class="subnav-button">Archival and Manuscripts</button>
+        <button class="subnav-button">Faculty Works</button>
+        <button class="subnav-button">Images and Maps</button>
+        <button class="subnav-button">Equipment and Gadgets</button>
+
+      </nav>
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--tools">
+      <label class="nav-button" for="nav-menu-tablet--tools">Tools</label>
+      <nav class="subnav-menu-main has-resources">
+
+        <label class="subnav-button -back" for="nav-menu-tablet--tools">Back to Main Menu</label>
+
+        <span class="subnav-menu-main-heading">Tools</span>
+
+        <label class="subnav-button -resource">
+          DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          Emory Center for Digital Scholarship
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          Ares <span class="subnav-button-alias">(Course Reserves)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+        <label class="subnav-button -resource">
+          LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+          <input type="checkbox" class="subnav-button-options-toggle">
+          <span class="subnav-button-options">
+            <a href="" class="subnav-button-option">
+              About
+            </a>
+            <a href="" class="subnav-button-option">
+              Access <span class="icon">&#x2192;</span>
+            </a>
+          </span>
+        </label>
+
+      </nav>
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--services">
+      <label class="nav-button" for="nav-menu-tablet--services">Services</label>
+      <nav class="subnav-menu-main -grouped">
+
+        <label class="subnav-button -back" for="nav-menu-tablet--services">Back to Main Menu</label>
+
+        <span class="subnav-menu-main-heading">Services</span>
+
+        <div class="subnav-button-group">
+
+          <span class="subnav-button-group-heading">Around the Library</span>
+
+          <button class="subnav-button">Reserve a Study or Presentation Room</button>
+          <button class="subnav-button">Find a Quiet Study Area</button>
+          <button class="subnav-button">Find a Workstation or Application</button>
+          <button class="subnav-button">Print, Copy, and Scan</button>
+
+        </div>
+
+        <div class="subnav-button-group">
+
+          <span class="subnav-button-group-heading">Get Assistance</span>
+
+          <button class="subnav-button">Borrow Equipment and Gadgets</button>
+          <button class="subnav-button">Research and Writing Assistance</button>
+          <button class="subnav-button">Access Course Reserves</button>
+          <button class="subnav-button">Request or Recall Materials</button>
+
+        </div>
+
+        <div class="subnav-button-group">
+
+          <span class="subnav-button-group-heading">Technology Assistance</span>
+
+          <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+          <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+          <button class="subnav-button">Get Hardware or Software Support</button>
+          <button class="subnav-button">Repair Your Device or Computer</button>
+
+        </div>
+
+        <div class="subnav-button-group">
+
+          <span class="subnav-button-group-heading">Make a Request</span>
+
+          <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+          <button class="subnav-button">Request a Purchase</button>
+          <button class="subnav-button">Submit Ask eJournals</button>
+          <button class="subnav-button">Apply for an Individual Study Room</button>
+
+        </div>
+
+        <button class="subnav-button -viewall -span">View All Services</button>
+
+      </nav>
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--research">
+      <label class="nav-button" for="nav-menu-tablet--research">Research</label>
+      <nav class="subnav-menu-main -categorized">
+
+        <label class="subnav-button -back" for="nav-menu-tablet--research">Back to Main Menu</label>
+
+        <span class="subnav-menu-main-heading">Research</span>
+
+        <button class="subnav-button">Subject Librarians Directory</button>
+        <button class="subnav-button">Research Data</button>
+        <button class="subnav-button">Award and Research Programs</button>
+
+        <div class="subnav-button-category">
+
+          <span class="subnav-button-category-heading">Help With Research</span>
+
+          <button class="subnav-button">Selecting Research Topics</button>
+          <button class="subnav-button">Finding Source Materials</button>
+          <button class="subnav-button">Evaluating Sources</button>
+          <button class="subnav-button">Citing and Using Sources</button>
+
+        </div>
+
+      </nav>
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--using-the-library">
+      <label class="nav-button" for="nav-menu-tablet--using-the-library">Using the Library</label>
+      <nav class="subnav-menu-main -categorized">
+
+        <label class="subnav-button -back" for="nav-menu-tablet--using-the-library">Back to Main Menu</label>
+
+        <span class="subnav-menu-main-heading">Using the Library</span>
+
+        <button class="subnav-button">Borrowing Privileges</button>
+        <button class="subnav-button">InterLibrary Lending (ILL)</button>
+        <button class="subnav-button">Library Maps and Spaces</button>
+        <button class="subnav-button">Course Reserves</button>
+        <button class="subnav-button">Guest Access</button>
+
+        <div class="subnav-button-category">
+
+          <span class="subnav-button-category-heading">Help Using the Library</span>
+
+          <button class="subnav-button">Search for Specific Items</button>
+          <button class="subnav-button">Questions About Articles</button>
+          <button class="subnav-button">Questions About Books</button>
+          <button class="subnav-button">Printing, Logging In, and Access</button>
+
+        </div>
+
+      </nav>
+
+    </nav>
+
+    <!-- mobile -->
+    <nav class="nav-menu-main -mobile">
+
+      <input type="checkbox" class="input -toggle" id="nav-menu-mobile--toggle">
+
+      <div class="nav-menu-main-toggles">
+
+        <label class="nav-button -toggle -open" for="nav-menu-mobile--toggle">
+          <span class="icon" aria-hidden="true" data-icon="material-menu">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+          </span>
+          Menu
+        </label>
+
+        <label class="nav-button -toggle -close" for="nav-menu-mobile--toggle">
+          <span class="icon" aria-hidden="true" data-icon="material-menu">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
+          </span>
+          Close
+        </label>
+
+      </div>
+
+      <nav class="nav-menu-main-menu">
+
+        <nav class="nav-menu-utility -mobile">
+
+          <div class="nav-menu-utility-right">
+
+            <label id="nav-button--events-&amp;-exhibits" for="nav-menu--events-&amp;-exhibits" tabindex="0" class="nav-button -flyout">
+              <span aria-hidden="true" data-icon="material-event" class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path fill="none" d="M0 0h24v24H0V0z"></path>
+                  <path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2zm-7 5h5v5h-5z"></path>
+                </svg>
+              </span>
+              <span class="nav-button-label">Events</span>
+            </label>
+            <label id="nav-button--maps" for="nav-menu--maps" tabindex="0" class="nav-button -flyout">
+              <span aria-hidden="true" data-icon="material-map" class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path fill="none" d="M0 0h24v24H0V0z"></path>
+                  <path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z"></path>
+                </svg>
+              </span>
+              <span class="nav-button-label">Maps</span>
+            </label>
+            <label id="nav-button--hours" for="nav-menu--hours" tabindex="0" class="nav-button -flyout">
+              <span aria-hidden="true" data-icon="material-access_time" class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path fill="none" d="M0 0h24v24H0V0z"></path>
+                  <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path>
+                </svg>
+              </span>
+              <span class="nav-button-label">Hours</span>
+            </label>
+            <label id="nav-button--news" for="nav-menu--news" tabindex="0" class="nav-button -flyout">
+              <span aria-hidden="true" data-icon="material-newspaper" class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z"></path>
+                </svg>
+              </span>
+              <span class="nav-button-label">News</span>
+            </label>
+            <label id="nav-button--contact" for="nav-menu--contact" tabindex="0" class="nav-button -flyout">
+              <span aria-hidden="true" data-icon="material-question_answer" class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path fill="none" d="M0 0h24v24H0V0z"></path>
+                  <path d="M15 4v7H5.17l-.59.59-.58.58V4h11m1-2H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm5 4h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1z"></path>
+                </svg>
+              </span>
+              <span class="nav-button-label">Contact</span>
+            </label>
+
+          </div>
+
+        </nav>
+
+        <div class="nav-menu-main-menu-area">
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--materials">
+          <label class="nav-button" for="nav-menu-mobile--materials">Materials</label>
+          <nav class="subnav-menu-main">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--materials">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Materials</span>
+
+            <button class="subnav-button">Books</button>
+            <button class="subnav-button">Films and Videos</button>
+            <button class="subnav-button">Music and Scores</button>
+            <button class="subnav-button">Journals</button>
+            <button class="subnav-button">Databases</button>
+            <button class="subnav-button">Course Reserves</button>
+            <button class="subnav-button">eBooks and Audiobooks</button>
+            <button class="subnav-button">Research and Library Guides</button>
+            <button class="subnav-button">Theses and Dissertations</button>
+            <button class="subnav-button">Archival and Manuscripts</button>
+            <button class="subnav-button">Faculty Works</button>
+            <button class="subnav-button">Images and Maps</button>
+            <button class="subnav-button">Equipment and Gadgets</button>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--tools">
+          <label class="nav-button" for="nav-menu-mobile--tools">Tools</label>
+          <nav class="subnav-menu-main has-resources">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--tools">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Tools</span>
+
+            <label class="subnav-button -resource">
+              DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Emory Center for Digital Scholarship
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Ares <span class="subnav-button-alias">(Course Reserves)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--services">
+          <label class="nav-button" for="nav-menu-mobile--services">Services</label>
+          <nav class="subnav-menu-main -grouped">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--services">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Services</span>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Around the Library</span>
+
+              <button class="subnav-button">Reserve a Study or Presentation Room</button>
+              <button class="subnav-button">Find a Quiet Study Area</button>
+              <button class="subnav-button">Find a Workstation or Application</button>
+              <button class="subnav-button">Print, Copy, and Scan</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Get Assistance</span>
+
+              <button class="subnav-button">Borrow Equipment and Gadgets</button>
+              <button class="subnav-button">Research and Writing Assistance</button>
+              <button class="subnav-button">Access Course Reserves</button>
+              <button class="subnav-button">Request or Recall Materials</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Technology Assistance</span>
+
+              <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+              <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+              <button class="subnav-button">Get Hardware or Software Support</button>
+              <button class="subnav-button">Repair Your Device or Computer</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Make a Request</span>
+
+              <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+              <button class="subnav-button">Request a Purchase</button>
+              <button class="subnav-button">Submit Ask eJournals</button>
+              <button class="subnav-button">Apply for an Individual Study Room</button>
+
+            </div>
+
+            <button class="subnav-button -viewall -span">View All Services</button>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--research">
+          <label class="nav-button" for="nav-menu-mobile--research">Research</label>
+          <nav class="subnav-menu-main -categorized">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--research">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Research</span>
+
+            <button class="subnav-button">Subject Librarians Directory</button>
+            <button class="subnav-button">Research Data</button>
+            <button class="subnav-button">Award and Research Programs</button>
+
+            <div class="subnav-button-category">
+
+              <span class="subnav-button-category-heading">Help With Research</span>
+
+              <button class="subnav-button">Selecting Research Topics</button>
+              <button class="subnav-button">Finding Source Materials</button>
+              <button class="subnav-button">Evaluating Sources</button>
+              <button class="subnav-button">Citing and Using Sources</button>
+
+            </div>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--using-the-library">
+          <label class="nav-button" for="nav-menu-mobile--using-the-library">Using the Library</label>
+          <nav class="subnav-menu-main -categorized">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--using-the-library">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Using the Library</span>
+
+            <button class="subnav-button">Borrowing Privileges</button>
+            <button class="subnav-button">InterLibrary Lending (ILL)</button>
+            <button class="subnav-button">Library Maps and Spaces</button>
+            <button class="subnav-button">Course Reserves</button>
+            <button class="subnav-button">Guest Access</button>
+
+            <div class="subnav-button-category">
+
+              <span class="subnav-button-category-heading">Help Using the Library</span>
+
+              <button class="subnav-button">Search for Specific Items</button>
+              <button class="subnav-button">Questions About Articles</button>
+              <button class="subnav-button">Questions About Books</button>
+              <button class="subnav-button">Printing, Logging In, and Access</button>
+
+            </div>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--initiatives">
+          <label class="nav-button" for="nav-menu-mobile--initiatives">Initiatives</label>
+          <nav class="subnav-menu-main">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--initiatives">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Initiatives</span>
+
+            <button class="subnav-button">Offices, Labs, and Departments</button>
+            <button class="subnav-button">Organizational Framework</button>
+            <button class="subnav-button">Collection Policies</button>
+            <button class="subnav-button">Digitization Program</button>
+            <button class="subnav-button">Digital Library Program</button>
+
+          </nav>
+
+          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--faculty-support">
+          <label class="nav-button" for="nav-menu-mobile--faculty-support">Faculty Support</label>
+          <nav class="subnav-menu-main">
+
+            <label class="subnav-button -back" for="nav-menu-mobile--faculty-support">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Faculty Support</span>
+
+            <button class="subnav-button">Emory Libraries Information Literacy Program</button>
+            <button class="subnav-button">Instructional Services for Faculty and TAs</button>
+            <button class="subnav-button">Creating Effective Research Assignments</button>
+            <button class="subnav-button">Media Booking Services for Instructors</button>
+            <button class="subnav-button">Request a Research Instruction Session</button>
+
+          </nav>
+
+        </div>
+
+        <a href="" class="nav-button -librarian">
+          <span aria-hidden="true" data-icon="material-help_outline" class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path></svg>
+          </span>
+          Ask a librarian
+        </a>
+
+      </nav>
+
+    </nav>
 
   </div>
 

--- a/test/comps-compounds.html
+++ b/test/comps-compounds.html
@@ -1165,661 +1165,24 @@
   <!-- compounds-nav-menu-main -->
   <div>
 
-    <!-- desktop -->
-    <nav class="nav-menu-main -desktop">
-
-      <div class="nav-menu-main-group">
-        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--materials">
-        <label class="nav-button" for="nav-menu-desktop--materials">Materials</label>
-        <nav class="subnav-menu-main">
-
-          <label class="subnav-button -back" for="nav-menu-desktop--materials">Back to Main Menu</label>
-
-          <span class="subnav-menu-main-heading">Materials</span>
-
-          <button class="subnav-button">Books</button>
-          <button class="subnav-button">Films and Videos</button>
-          <button class="subnav-button">Music and Scores</button>
-          <button class="subnav-button">Journals</button>
-          <button class="subnav-button">Databases</button>
-          <button class="subnav-button">Course Reserves</button>
-          <button class="subnav-button">eBooks and Audiobooks</button>
-          <button class="subnav-button">Research and Library Guides</button>
-          <button class="subnav-button">Theses and Dissertations</button>
-          <button class="subnav-button">Archival and Manuscripts</button>
-          <button class="subnav-button">Faculty Works</button>
-          <button class="subnav-button">Images and Maps</button>
-          <button class="subnav-button">Equipment and Gadgets</button>
-
-        </nav>
-      </div>
-
-      <div class="nav-menu-main-group">
-        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--tools">
-        <label class="nav-button" for="nav-menu-desktop--tools">Tools</label>
-        <nav class="subnav-menu-main has-resources">
-
-          <label class="subnav-button -back" for="nav-menu-desktop--tools">Back to Main Menu</label>
-
-          <span class="subnav-menu-main-heading">Tools</span>
-
-          <label class="subnav-button -resource">
-            DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            eJournals <span class="subnav-button-alias">(Academic Journals)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            Emory Center for Digital Scholarship
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            Ares <span class="subnav-button-alias">(Course Reserves)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-          <label class="subnav-button -resource">
-            LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
-            <input type="checkbox" class="subnav-button-options-toggle">
-            <span class="subnav-button-options">
-              <a href="" class="subnav-button-option">
-                About
-              </a>
-              <a href="" class="subnav-button-option">
-                Access <span class="icon">&#x2192;</span>
-              </a>
-            </span>
-          </label>
-
-        </nav>
-      </div>
-
-      <div class="nav-menu-main-group">
-        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--services">
-        <label class="nav-button" for="nav-menu-desktop--services">Services</label>
-        <nav class="subnav-menu-main -grouped">
-
-          <label class="subnav-button -back" for="nav-menu-desktop--services">Back to Main Menu</label>
-
-          <span class="subnav-menu-main-heading">Services</span>
-
-          <div class="subnav-button-group">
-
-            <span class="subnav-button-group-heading">Around the Library</span>
-
-            <button class="subnav-button">Reserve a Study or Presentation Room</button>
-            <button class="subnav-button">Find a Quiet Study Area</button>
-            <button class="subnav-button">Find a Workstation or Application</button>
-            <button class="subnav-button">Print, Copy, and Scan</button>
-
-          </div>
-
-          <div class="subnav-button-group">
-
-            <span class="subnav-button-group-heading">Get Assistance</span>
-
-            <button class="subnav-button">Borrow Equipment and Gadgets</button>
-            <button class="subnav-button">Research and Writing Assistance</button>
-            <button class="subnav-button">Access Course Reserves</button>
-            <button class="subnav-button">Request or Recall Materials</button>
-
-          </div>
-
-          <div class="subnav-button-group">
-
-            <span class="subnav-button-group-heading">Technology Assistance</span>
-
-            <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
-            <button class="subnav-button">Connect to the Internet (On-Campus)</button>
-            <button class="subnav-button">Get Hardware or Software Support</button>
-            <button class="subnav-button">Repair Your Device or Computer</button>
-
-          </div>
-
-          <div class="subnav-button-group">
-
-            <span class="subnav-button-group-heading">Make a Request</span>
-
-            <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
-            <button class="subnav-button">Request a Purchase</button>
-            <button class="subnav-button">Submit Ask eJournals</button>
-            <button class="subnav-button">Apply for an Individual Study Room</button>
-
-          </div>
-
-          <button class="subnav-button -viewall -span">View All Services</button>
-
-        </nav>
-      </div>
-
-      <div class="nav-menu-main-group">
-        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--research">
-        <label class="nav-button" for="nav-menu-desktop--research">Research</label>
-        <nav class="subnav-menu-main -categorized">
-
-          <label class="subnav-button -back" for="nav-menu-desktop--research">Back to Main Menu</label>
-
-          <span class="subnav-menu-main-heading">Research</span>
-
-          <button class="subnav-button">Subject Librarians Directory</button>
-          <button class="subnav-button">Research Data</button>
-          <button class="subnav-button">Award and Research Programs</button>
-
-          <div class="subnav-button-category">
-
-            <span class="subnav-button-category-heading">Help With Research</span>
-
-            <button class="subnav-button">Selecting Research Topics</button>
-            <button class="subnav-button">Finding Source Materials</button>
-            <button class="subnav-button">Evaluating Sources</button>
-            <button class="subnav-button">Citing and Using Sources</button>
-
-          </div>
-
-        </nav>
-      </div>
-
-      <div class="nav-menu-main-group">
-        <input type="checkbox" class="input -toggle" id="nav-menu-desktop--using-the-library">
-        <label class="nav-button" for="nav-menu-desktop--using-the-library">Using the Library</label>
-        <nav class="subnav-menu-main -categorized">
-
-          <label class="subnav-button -back" for="nav-menu-desktop--using-the-library">Back to Main Menu</label>
-
-          <span class="subnav-menu-main-heading">Using the Library</span>
-
-          <button class="subnav-button">Borrowing Privileges</button>
-          <button class="subnav-button">InterLibrary Lending (ILL)</button>
-          <button class="subnav-button">Library Maps and Spaces</button>
-          <button class="subnav-button">Course Reserves</button>
-          <button class="subnav-button">Guest Access</button>
-
-          <div class="subnav-button-category">
-
-            <span class="subnav-button-category-heading">Help Using the Library</span>
-
-            <button class="subnav-button">Search for Specific Items</button>
-            <button class="subnav-button">Questions About Articles</button>
-            <button class="subnav-button">Questions About Books</button>
-            <button class="subnav-button">Printing, Logging In, and Access</button>
-
-          </div>
-
-        </nav>
-      </div>
-
-    </nav>
-
-    <!-- tablet -->
-    <nav class="nav-menu-main -tablet">
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--materials">
-      <label class="nav-button" for="nav-menu-tablet--materials">Materials</label>
-      <nav class="subnav-menu-main">
-
-        <label class="subnav-button -back" for="nav-menu-tablet--materials">Back to Main Menu</label>
-
-        <span class="subnav-menu-main-heading">Materials</span>
-
-        <button class="subnav-button">Books</button>
-        <button class="subnav-button">Films and Videos</button>
-        <button class="subnav-button">Music and Scores</button>
-        <button class="subnav-button">Journals</button>
-        <button class="subnav-button">Databases</button>
-        <button class="subnav-button">Course Reserves</button>
-        <button class="subnav-button">eBooks and Audiobooks</button>
-        <button class="subnav-button">Research and Library Guides</button>
-        <button class="subnav-button">Theses and Dissertations</button>
-        <button class="subnav-button">Archival and Manuscripts</button>
-        <button class="subnav-button">Faculty Works</button>
-        <button class="subnav-button">Images and Maps</button>
-        <button class="subnav-button">Equipment and Gadgets</button>
-
-      </nav>
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--tools">
-      <label class="nav-button" for="nav-menu-tablet--tools">Tools</label>
-      <nav class="subnav-menu-main has-resources">
-
-        <label class="subnav-button -back" for="nav-menu-tablet--tools">Back to Main Menu</label>
-
-        <span class="subnav-menu-main-heading">Tools</span>
-
-        <label class="subnav-button -resource">
-          DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          eJournals <span class="subnav-button-alias">(Academic Journals)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          Emory Center for Digital Scholarship
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          Ares <span class="subnav-button-alias">(Course Reserves)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-        <label class="subnav-button -resource">
-          LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
-          <input type="checkbox" class="subnav-button-options-toggle">
-          <span class="subnav-button-options">
-            <a href="" class="subnav-button-option">
-              About
-            </a>
-            <a href="" class="subnav-button-option">
-              Access <span class="icon">&#x2192;</span>
-            </a>
-          </span>
-        </label>
-
-      </nav>
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--services">
-      <label class="nav-button" for="nav-menu-tablet--services">Services</label>
-      <nav class="subnav-menu-main -grouped">
-
-        <label class="subnav-button -back" for="nav-menu-tablet--services">Back to Main Menu</label>
-
-        <span class="subnav-menu-main-heading">Services</span>
-
-        <div class="subnav-button-group">
-
-          <span class="subnav-button-group-heading">Around the Library</span>
-
-          <button class="subnav-button">Reserve a Study or Presentation Room</button>
-          <button class="subnav-button">Find a Quiet Study Area</button>
-          <button class="subnav-button">Find a Workstation or Application</button>
-          <button class="subnav-button">Print, Copy, and Scan</button>
-
-        </div>
-
-        <div class="subnav-button-group">
-
-          <span class="subnav-button-group-heading">Get Assistance</span>
-
-          <button class="subnav-button">Borrow Equipment and Gadgets</button>
-          <button class="subnav-button">Research and Writing Assistance</button>
-          <button class="subnav-button">Access Course Reserves</button>
-          <button class="subnav-button">Request or Recall Materials</button>
-
-        </div>
-
-        <div class="subnav-button-group">
-
-          <span class="subnav-button-group-heading">Technology Assistance</span>
-
-          <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
-          <button class="subnav-button">Connect to the Internet (On-Campus)</button>
-          <button class="subnav-button">Get Hardware or Software Support</button>
-          <button class="subnav-button">Repair Your Device or Computer</button>
-
-        </div>
-
-        <div class="subnav-button-group">
-
-          <span class="subnav-button-group-heading">Make a Request</span>
-
-          <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
-          <button class="subnav-button">Request a Purchase</button>
-          <button class="subnav-button">Submit Ask eJournals</button>
-          <button class="subnav-button">Apply for an Individual Study Room</button>
-
-        </div>
-
-        <button class="subnav-button -viewall -span">View All Services</button>
-
-      </nav>
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--research">
-      <label class="nav-button" for="nav-menu-tablet--research">Research</label>
-      <nav class="subnav-menu-main -categorized">
-
-        <label class="subnav-button -back" for="nav-menu-tablet--research">Back to Main Menu</label>
-
-        <span class="subnav-menu-main-heading">Research</span>
-
-        <button class="subnav-button">Subject Librarians Directory</button>
-        <button class="subnav-button">Research Data</button>
-        <button class="subnav-button">Award and Research Programs</button>
-
-        <div class="subnav-button-category">
-
-          <span class="subnav-button-category-heading">Help With Research</span>
-
-          <button class="subnav-button">Selecting Research Topics</button>
-          <button class="subnav-button">Finding Source Materials</button>
-          <button class="subnav-button">Evaluating Sources</button>
-          <button class="subnav-button">Citing and Using Sources</button>
-
-        </div>
-
-      </nav>
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-tablet--using-the-library">
-      <label class="nav-button" for="nav-menu-tablet--using-the-library">Using the Library</label>
-      <nav class="subnav-menu-main -categorized">
-
-        <label class="subnav-button -back" for="nav-menu-tablet--using-the-library">Back to Main Menu</label>
-
-        <span class="subnav-menu-main-heading">Using the Library</span>
-
-        <button class="subnav-button">Borrowing Privileges</button>
-        <button class="subnav-button">InterLibrary Lending (ILL)</button>
-        <button class="subnav-button">Library Maps and Spaces</button>
-        <button class="subnav-button">Course Reserves</button>
-        <button class="subnav-button">Guest Access</button>
-
-        <div class="subnav-button-category">
-
-          <span class="subnav-button-category-heading">Help Using the Library</span>
-
-          <button class="subnav-button">Search for Specific Items</button>
-          <button class="subnav-button">Questions About Articles</button>
-          <button class="subnav-button">Questions About Books</button>
-          <button class="subnav-button">Printing, Logging In, and Access</button>
-
-        </div>
-
-      </nav>
-
-    </nav>
-
-    <!-- mobile -->
-    <nav class="nav-menu-main -mobile">
-
-      <input type="checkbox" class="input -toggle" id="nav-menu-mobile--toggle">
-
-      <div class="nav-menu-main-toggles">
-
-        <label class="nav-button -toggle -open" for="nav-menu-mobile--toggle">
-          <span class="icon" aria-hidden="true" data-icon="material-menu">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
-          </span>
-          Menu
-        </label>
-
-        <label class="nav-button -toggle -close" for="nav-menu-mobile--toggle">
-          <span class="icon" aria-hidden="true" data-icon="material-menu">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
-          </span>
-          Close
-        </label>
-
-      </div>
-
-      <nav class="nav-menu-main-menu">
-
-        <nav class="nav-menu-utility -mobile">
-
-          <div class="nav-menu-utility-right">
-
-            <label id="nav-button--events-&amp;-exhibits" for="nav-menu--events-&amp;-exhibits" tabindex="0" class="nav-button -flyout">
-              <span aria-hidden="true" data-icon="material-event" class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                  <path fill="none" d="M0 0h24v24H0V0z"></path>
-                  <path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2zm-7 5h5v5h-5z"></path>
-                </svg>
-              </span>
-              <span class="nav-button-label">Events</span>
-            </label>
-            <label id="nav-button--maps" for="nav-menu--maps" tabindex="0" class="nav-button -flyout">
-              <span aria-hidden="true" data-icon="material-map" class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                  <path fill="none" d="M0 0h24v24H0V0z"></path>
-                  <path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z"></path>
-                </svg>
-              </span>
-              <span class="nav-button-label">Maps</span>
-            </label>
-            <label id="nav-button--hours" for="nav-menu--hours" tabindex="0" class="nav-button -flyout">
-              <span aria-hidden="true" data-icon="material-access_time" class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                  <path fill="none" d="M0 0h24v24H0V0z"></path>
-                  <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path>
-                </svg>
-              </span>
-              <span class="nav-button-label">Hours</span>
-            </label>
-            <label id="nav-button--news" for="nav-menu--news" tabindex="0" class="nav-button -flyout">
-              <span aria-hidden="true" data-icon="material-newspaper" class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                  <path d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z"></path>
-                </svg>
-              </span>
-              <span class="nav-button-label">News</span>
-            </label>
-            <label id="nav-button--contact" for="nav-menu--contact" tabindex="0" class="nav-button -flyout">
-              <span aria-hidden="true" data-icon="material-question_answer" class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                  <path fill="none" d="M0 0h24v24H0V0z"></path>
-                  <path d="M15 4v7H5.17l-.59.59-.58.58V4h11m1-2H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm5 4h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1z"></path>
-                </svg>
-              </span>
-              <span class="nav-button-label">Contact</span>
-            </label>
-
-          </div>
-
-        </nav>
-
-        <div class="nav-menu-main-menu-area">
-
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--materials">
-          <label class="nav-button" for="nav-menu-mobile--materials">Materials</label>
+    <nav class="nav-menu-main">
+
+      <input type="checkbox" class="input -toggle" id="nav-menu--materials">
+      <input type="checkbox" class="input -toggle" id="nav-menu--tools">
+      <input type="checkbox" class="input -toggle" id="nav-menu--services">
+      <input type="checkbox" class="input -toggle" id="nav-menu--research">
+      <input type="checkbox" class="input -toggle" id="nav-menu--using-the-library">
+      <input type="checkbox" class="input -toggle" id="nav-menu--initiatives">
+      <input type="checkbox" class="input -toggle" id="nav-menu--faculty-support">
+
+      <!-- desktop -->
+      <nav class="nav-menu-main-nav -desktop">
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--materials">Materials</label>
           <nav class="subnav-menu-main">
 
-            <label class="subnav-button -back" for="nav-menu-mobile--materials">Back to Main Menu</label>
+            <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
 
             <span class="subnav-menu-main-heading">Materials</span>
 
@@ -1838,12 +1201,13 @@
             <button class="subnav-button">Equipment and Gadgets</button>
 
           </nav>
+        </div>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--tools">
-          <label class="nav-button" for="nav-menu-mobile--tools">Tools</label>
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--tools">Tools</label>
           <nav class="subnav-menu-main has-resources">
 
-            <label class="subnav-button -back" for="nav-menu-mobile--tools">Back to Main Menu</label>
+            <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
 
             <span class="subnav-menu-main-heading">Tools</span>
 
@@ -1981,12 +1345,13 @@
             </label>
 
           </nav>
+        </div>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--services">
-          <label class="nav-button" for="nav-menu-mobile--services">Services</label>
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--services">Services</label>
           <nav class="subnav-menu-main -grouped">
 
-            <label class="subnav-button -back" for="nav-menu-mobile--services">Back to Main Menu</label>
+            <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
 
             <span class="subnav-menu-main-heading">Services</span>
 
@@ -2037,12 +1402,13 @@
             <button class="subnav-button -viewall -span">View All Services</button>
 
           </nav>
+        </div>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--research">
-          <label class="nav-button" for="nav-menu-mobile--research">Research</label>
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--research">Research</label>
           <nav class="subnav-menu-main -categorized">
 
-            <label class="subnav-button -back" for="nav-menu-mobile--research">Back to Main Menu</label>
+            <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
 
             <span class="subnav-menu-main-heading">Research</span>
 
@@ -2062,12 +1428,13 @@
             </div>
 
           </nav>
+        </div>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--using-the-library">
-          <label class="nav-button" for="nav-menu-mobile--using-the-library">Using the Library</label>
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
           <nav class="subnav-menu-main -categorized">
 
-            <label class="subnav-button -back" for="nav-menu-mobile--using-the-library">Back to Main Menu</label>
+            <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
 
             <span class="subnav-menu-main-heading">Using the Library</span>
 
@@ -2089,47 +1456,673 @@
             </div>
 
           </nav>
+        </div>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--initiatives">
-          <label class="nav-button" for="nav-menu-mobile--initiatives">Initiatives</label>
-          <nav class="subnav-menu-main">
+      </nav>
 
-            <label class="subnav-button -back" for="nav-menu-mobile--initiatives">Back to Main Menu</label>
+      <!-- tablet -->
+      <nav class="nav-menu-main-nav -tablet">
 
-            <span class="subnav-menu-main-heading">Initiatives</span>
+        <label class="nav-button" for="nav-menu--materials">Materials</label>
+        <nav class="subnav-menu-main">
 
-            <button class="subnav-button">Offices, Labs, and Departments</button>
-            <button class="subnav-button">Organizational Framework</button>
-            <button class="subnav-button">Collection Policies</button>
-            <button class="subnav-button">Digitization Program</button>
-            <button class="subnav-button">Digital Library Program</button>
+          <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
 
-          </nav>
+          <span class="subnav-menu-main-heading">Materials</span>
 
-          <input type="checkbox" class="input -toggle" id="nav-menu-mobile--faculty-support">
-          <label class="nav-button" for="nav-menu-mobile--faculty-support">Faculty Support</label>
-          <nav class="subnav-menu-main">
+          <button class="subnav-button">Books</button>
+          <button class="subnav-button">Films and Videos</button>
+          <button class="subnav-button">Music and Scores</button>
+          <button class="subnav-button">Journals</button>
+          <button class="subnav-button">Databases</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">eBooks and Audiobooks</button>
+          <button class="subnav-button">Research and Library Guides</button>
+          <button class="subnav-button">Theses and Dissertations</button>
+          <button class="subnav-button">Archival and Manuscripts</button>
+          <button class="subnav-button">Faculty Works</button>
+          <button class="subnav-button">Images and Maps</button>
+          <button class="subnav-button">Equipment and Gadgets</button>
 
-            <label class="subnav-button -back" for="nav-menu-mobile--faculty-support">Back to Main Menu</label>
+        </nav>
 
-            <span class="subnav-menu-main-heading">Faculty Support</span>
+        <label class="nav-button" for="nav-menu--tools">Tools</label>
+        <nav class="subnav-menu-main has-resources">
 
-            <button class="subnav-button">Emory Libraries Information Literacy Program</button>
-            <button class="subnav-button">Instructional Services for Faculty and TAs</button>
-            <button class="subnav-button">Creating Effective Research Assignments</button>
-            <button class="subnav-button">Media Booking Services for Instructors</button>
-            <button class="subnav-button">Request a Research Instruction Session</button>
+          <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
 
-          </nav>
+          <span class="subnav-menu-main-heading">Tools</span>
+
+          <label class="subnav-button -resource">
+            DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Center for Digital Scholarship
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Ares <span class="subnav-button-alias">(Course Reserves)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--services">Services</label>
+        <nav class="subnav-menu-main -grouped">
+
+          <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Services</span>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Around the Library</span>
+
+            <button class="subnav-button">Reserve a Study or Presentation Room</button>
+            <button class="subnav-button">Find a Quiet Study Area</button>
+            <button class="subnav-button">Find a Workstation or Application</button>
+            <button class="subnav-button">Print, Copy, and Scan</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Get Assistance</span>
+
+            <button class="subnav-button">Borrow Equipment and Gadgets</button>
+            <button class="subnav-button">Research and Writing Assistance</button>
+            <button class="subnav-button">Access Course Reserves</button>
+            <button class="subnav-button">Request or Recall Materials</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Technology Assistance</span>
+
+            <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+            <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+            <button class="subnav-button">Get Hardware or Software Support</button>
+            <button class="subnav-button">Repair Your Device or Computer</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Make a Request</span>
+
+            <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+            <button class="subnav-button">Request a Purchase</button>
+            <button class="subnav-button">Submit Ask eJournals</button>
+            <button class="subnav-button">Apply for an Individual Study Room</button>
+
+          </div>
+
+          <button class="subnav-button -viewall -span">View All Services</button>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--research">Research</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <!-- <label class="subnav-button -back" for="nav-menu-tablet--research">Back to Main Menu</label> -->
+          <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Research</span>
+
+          <button class="subnav-button">Subject Librarians Directory</button>
+          <button class="subnav-button">Research Data</button>
+          <button class="subnav-button">Award and Research Programs</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help With Research</span>
+
+            <button class="subnav-button">Selecting Research Topics</button>
+            <button class="subnav-button">Finding Source Materials</button>
+            <button class="subnav-button">Evaluating Sources</button>
+            <button class="subnav-button">Citing and Using Sources</button>
+
+          </div>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Using the Library</span>
+
+          <button class="subnav-button">Borrowing Privileges</button>
+          <button class="subnav-button">InterLibrary Lending (ILL)</button>
+          <button class="subnav-button">Library Maps and Spaces</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">Guest Access</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help Using the Library</span>
+
+            <button class="subnav-button">Search for Specific Items</button>
+            <button class="subnav-button">Questions About Articles</button>
+            <button class="subnav-button">Questions About Books</button>
+            <button class="subnav-button">Printing, Logging In, and Access</button>
+
+          </div>
+
+        </nav>
+
+      </nav>
+
+      <!-- mobile -->
+      <nav class="nav-menu-main-nav -mobile">
+
+        <input type="checkbox" class="input -toggle" id="nav-menu-mobile--toggle">
+
+        <div class="nav-menu-main-nav-toggles">
+
+          <label class="nav-button -toggle -open" for="nav-menu-mobile--toggle">
+            <span class="icon" aria-hidden="true" data-icon="material-menu">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+            </span>
+            Menu
+          </label>
+
+          <label class="nav-button -toggle -close" for="nav-menu-mobile--toggle">
+            <span class="icon" aria-hidden="true" data-icon="material-menu">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
+            </span>
+            Close
+          </label>
 
         </div>
 
-        <a href="" class="nav-button -librarian">
-          <span aria-hidden="true" data-icon="material-help_outline" class="icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path></svg>
-          </span>
-          Ask a librarian
-        </a>
+        <nav class="nav-menu-main-nav-menu">
+
+          <nav class="nav-menu-utility -mobile">
+
+            <div class="nav-menu-utility-right">
+
+              <label id="nav-button--events-exhibits" for="nav-menu--events-exhibits" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-event" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2zm-7 5h5v5h-5z"></path>
+                  </svg>
+                </span>
+                Events
+              </label>
+              <label id="nav-button--maps" for="nav-menu--maps" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-map" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z"></path>
+                  </svg>
+                </span>
+                Maps
+              </label>
+              <label id="nav-button--hours" for="nav-menu--hours" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-access_time" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path>
+                  </svg>
+                </span>
+                Hours
+              </label>
+              <label id="nav-button--news" for="nav-menu--news" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-newspaper" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z"></path>
+                  </svg>
+                </span>
+                News
+              </label>
+              <label id="nav-button--contact" for="nav-menu--contact" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-question_answer" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M15 4v7H5.17l-.59.59-.58.58V4h11m1-2H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm5 4h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1z"></path>
+                  </svg>
+                </span>
+                Contact
+              </label>
+
+            </div>
+
+          </nav>
+
+          <div class="nav-menu-main-nav-menu-area">
+
+            <label class="nav-button" for="nav-menu--materials">Materials</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Materials</span>
+
+              <button class="subnav-button">Books</button>
+              <button class="subnav-button">Films and Videos</button>
+              <button class="subnav-button">Music and Scores</button>
+              <button class="subnav-button">Journals</button>
+              <button class="subnav-button">Databases</button>
+              <button class="subnav-button">Course Reserves</button>
+              <button class="subnav-button">eBooks and Audiobooks</button>
+              <button class="subnav-button">Research and Library Guides</button>
+              <button class="subnav-button">Theses and Dissertations</button>
+              <button class="subnav-button">Archival and Manuscripts</button>
+              <button class="subnav-button">Faculty Works</button>
+              <button class="subnav-button">Images and Maps</button>
+              <button class="subnav-button">Equipment and Gadgets</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--tools">Tools</label>
+            <nav class="subnav-menu-main has-resources">
+
+              <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Tools</span>
+
+              <label class="subnav-button -resource">
+                DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Emory Center for Digital Scholarship
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Ares <span class="subnav-button-alias">(Course Reserves)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--services">Services</label>
+            <nav class="subnav-menu-main -grouped">
+
+              <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Services</span>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Around the Library</span>
+
+                <button class="subnav-button">Reserve a Study or Presentation Room</button>
+                <button class="subnav-button">Find a Quiet Study Area</button>
+                <button class="subnav-button">Find a Workstation or Application</button>
+                <button class="subnav-button">Print, Copy, and Scan</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Get Assistance</span>
+
+                <button class="subnav-button">Borrow Equipment and Gadgets</button>
+                <button class="subnav-button">Research and Writing Assistance</button>
+                <button class="subnav-button">Access Course Reserves</button>
+                <button class="subnav-button">Request or Recall Materials</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Technology Assistance</span>
+
+                <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+                <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+                <button class="subnav-button">Get Hardware or Software Support</button>
+                <button class="subnav-button">Repair Your Device or Computer</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Make a Request</span>
+
+                <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+                <button class="subnav-button">Request a Purchase</button>
+                <button class="subnav-button">Submit Ask eJournals</button>
+                <button class="subnav-button">Apply for an Individual Study Room</button>
+
+              </div>
+
+              <button class="subnav-button -viewall -span">View All Services</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--research">Research</label>
+            <nav class="subnav-menu-main -categorized">
+
+              <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Research</span>
+
+              <button class="subnav-button">Subject Librarians Directory</button>
+              <button class="subnav-button">Research Data</button>
+              <button class="subnav-button">Award and Research Programs</button>
+
+              <div class="subnav-button-category">
+
+                <span class="subnav-button-category-heading">Help With Research</span>
+
+                <button class="subnav-button">Selecting Research Topics</button>
+                <button class="subnav-button">Finding Source Materials</button>
+                <button class="subnav-button">Evaluating Sources</button>
+                <button class="subnav-button">Citing and Using Sources</button>
+
+              </div>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
+            <nav class="subnav-menu-main -categorized">
+
+              <!--label class="subnav-button -back" for="nav-menu-mobile--using-the-library">Back to Main Menu</label-->
+              <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Using the Library</span>
+
+              <button class="subnav-button">Borrowing Privileges</button>
+              <button class="subnav-button">InterLibrary Lending (ILL)</button>
+              <button class="subnav-button">Library Maps and Spaces</button>
+              <button class="subnav-button">Course Reserves</button>
+              <button class="subnav-button">Guest Access</button>
+
+              <div class="subnav-button-category">
+
+                <span class="subnav-button-category-heading">Help Using the Library</span>
+
+                <button class="subnav-button">Search for Specific Items</button>
+                <button class="subnav-button">Questions About Articles</button>
+                <button class="subnav-button">Questions About Books</button>
+                <button class="subnav-button">Printing, Logging In, and Access</button>
+
+              </div>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--initiatives">Initiatives</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--initiatives">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Initiatives</span>
+
+              <button class="subnav-button">Offices, Labs, and Departments</button>
+              <button class="subnav-button">Organizational Framework</button>
+              <button class="subnav-button">Collection Policies</button>
+              <button class="subnav-button">Digitization Program</button>
+              <button class="subnav-button">Digital Library Program</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--faculty-support">Faculty Support</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--faculty-support">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Faculty Support</span>
+
+              <button class="subnav-button">Emory Libraries Information Literacy Program</button>
+              <button class="subnav-button">Instructional Services for Faculty and TAs</button>
+              <button class="subnav-button">Creating Effective Research Assignments</button>
+              <button class="subnav-button">Media Booking Services for Instructors</button>
+              <button class="subnav-button">Request a Research Instruction Session</button>
+
+            </nav>
+
+          </div>
+
+          <a href="" class="nav-button -librarian">
+            <span aria-hidden="true" data-icon="material-help_outline" class="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path></svg>
+            </span>
+            Ask a librarian
+          </a>
+
+        </nav>
 
       </nav>
 

--- a/test/comps-compounds.scss
+++ b/test/comps-compounds.scss
@@ -54,3 +54,8 @@
 .slider {
   @include compounds-slider;
 }
+
+// compounds-nav-menu-main
+.nav-menu-main {
+  @include compounds-nav-menu-main;
+}

--- a/test/comps-organisms.html
+++ b/test/comps-organisms.html
@@ -170,6 +170,1128 @@
 
   </div>
 
+  <!-- organisms-nav-bar-main -->
+  <div class="nav-bar-main">
+
+    <!-- Branding (molecules-header-branding) -->
+    <div class="branding-header">
+      <div class="branding-header-badge">
+        <span class="logo">
+          <svg version="1.1" id="logo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" xml:space="preserve">
+            <g id="badge">
+              <g>
+                <path d="M49.5,90.4C8.9,71.7,13.8,29.7,13.8,10.1l71.8,0.1C85.6,29.8,90.1,71.8,49.5,90.4z M13.8,6.9l-3.1,3.3
+                      c0,2.3-0.1,5.3-0.1,6.7c-0.3,23,1.3,58.8,38.7,76.2c19.8-9.2,34.8-25,38.8-49.5C90.4,29.5,89,16,89,6.9L13.8,6.9z" />
+                <path d="M34.2,58.4c-2.9,3.1-5.7,6.1-6.7,7.1c-0.2,0.2-0.2,0.5-0.1,0.6c0.2,0.2,0.5,0.5,0.6,0.5
+                      c0.2,0,0.3,0.1,0.6-0.2c0.1-0.1,3.3-3.2,7-6.8c0,0-0.4-0.2-0.7-0.5C34.6,58.9,34.2,58.4,34.2,58.4z" />
+                <g>
+                  <path d="M36.1,57.6C36.8,58.3,38,59,38,59l-0.7,0.6c-0.3,0.3-1.2-0.2-2.1-1c-0.9-0.8-1.4-1.7-1.2-1.9l0.7-0.7
+                          C34.9,56,35.4,56.9,36.1,57.6z" />
+                </g>
+                <g>
+                  <g>
+                    <g>
+                      <path d="M68.9,65.5c0.6-0.6,0.6-1.1,0.6-1.1l0.7,0.3c0.2,0.2,0,1-0.6,1.6C69,66.8,68.2,67,68,66.8l-0.3-0.7
+                                  C67.6,66.1,68.3,66.1,68.9,65.5z" />
+                    </g>
+                  </g>
+                  <g>
+                    <g>
+                      <path d="M67.9,64.4c0.4-0.3,0.5-0.8,0.5-0.8l0.4,0.3c0.1,0.1,0,0.6-0.4,1.1c-0.4,0.4-1,0.6-1.2,0.4L67,64.9
+                                  C67,64.9,67.5,64.8,67.9,64.4z" />
+                    </g>
+                  </g>
+                </g>
+                <g>
+                  <path d="M65.3,27.7c1.3,1.2,2.6,2.2,3.7,2.7c0-0.1-0.1-0.1-0.1-0.2c-1-1.5-3.8-3.6-5.9-5.1
+                          C63.4,25.9,64.1,26.7,65.3,27.7z" />
+                  <path d="M69.9,31.7l-0.7,0.7c-1,0.4-3.4-1.4-5.3-3.1c-1.2-1.1-3.8-3.9-3-5l0.3-0.3c-0.2-0.1-0.4-0.3-0.6-0.3
+                          c-0.2-0.1-0.5-0.2-0.8-0.1c-0.3,0-0.5,0.2-0.6,0.4c-0.1,0.5,0.2,1.2,0.6,1.9c0.4,0.8,2,3,5.1,5.5c1.4,1.1,3.1,1.8,4.3,2.3
+                          c0.2,0.1,1,0.2,1.3-0.1c0.3-0.3,0-0.9-0.3-1.5C70.1,32,70,31.8,69.9,31.7z" />
+                </g>
+                <path d="M67.7,63.3c-1.2-1.4-10.5-12.3-11.9-14c-1.5-1.8-11-13.1-14.1-17c-3.6-4.5-4.3-10.9-4.3-11.6
+                      c0-0.3,0-0.5,0-0.8c0-0.1-0.2-0.1-0.2,0c-0.2,0.4-1.3,2.6-4.7,5.9c-2.5,2.3-5.6,4.2-7,4.7c-0.1,0-0.1,0.1-0.1,0.1
+                      c0.2,0.1,2.5,0.2,2.5,0.2c3.3,0.3,4.6,1.3,7.6,3.2c3.4,2.2,11.7,10.2,13.2,11.7c1.6,1.5,17.6,17.6,18,18c0,0,0.2,0.3,0.3,0.3
+                      c0,0,0.3,0,0.6-0.3c0.3-0.2,0.4-0.5,0.4-0.5C67.8,63.4,67.7,63.3,67.7,63.3z M66.1,62.8c0,0-8.9-9-14.5-14.8
+                      C40.6,36.5,35.5,33,32.8,31.6c-1.5-0.8-3.2-1.2-3.5-1.3c-0.2-0.1-0.3-0.3,0.2-0.7c0.6-0.5,1.6-1,2.2-1.2c0.2-0.1,1,0.2,1.8,0.5
+                      c1.5,0.6,2.8,1.4,6.1,4.7c1.1,1.1,2.4,2.4,3.8,3.9c10.1,10.7,23,25.2,23,25.2L66.1,62.8z" />
+                <path d="M74.1,23.7c-0.3,0.4-0.9,1.3-1.2,1.6c0.4-0.3,0.6-1.1,0.2-3.2c-0.3-1.5-0.5-1.9-0.7-2.4
+                      c-0.1-0.3-0.3-0.2-0.5,0c-0.2,0.2-0.6,1-0.6,1c0,0.2,0,0-0.7-2.1c-0.4-1.3-0.6-2.3-0.6-2.8c0-0.3,0-0.5,0-0.7c0-0.2-0.1-0.2-0.5,0
+                      c-0.2,0.1-2,1.4-2.8,3.3c-0.4,1.1-0.5,2-0.5,1.5c-0.1-1.1-0.1-1.1-0.2-1c-0.6,0.2-2.6,1.1-2.7,3.8c-0.5-0.1-0.9-0.1-1.1,0.1
+                      c-0.7,0.7,0.8,3.1,3.2,5.4c2.4,2.3,5,3.5,5.6,2.8c0.3-0.3,0.2-0.8-0.2-1.6c0.2,0,0.5-0.1,0.7-0.1c0,0,2.8-0.5,2.9-3.1
+                      C74.4,23.5,74.1,23.7,74.1,23.7z M73.3,26.9c-0.2,0.3-0.7,0.9-1.5,1.3c-0.9,0.4-2.1,0.5-2.7,0.3c-2.8-0.9-4.5-3.7-4.5-3.7
+                      c-2.2-3.6,0.8-5.1,1-5.2c0,0-0.3,1.2-0.1,2c0.2,0.7,0.6,1.3,0.7,1.7c0.3,0.8-0.1,1.3-0.3,1.6c-0.1,0.1,0.2,0.1,0.2,0
+                      c0,0,0.1-0.1,0.2-0.1c0.4-0.3,0.8-0.8,0.7-1.3c-0.3-1.1-1.1-1.8-0.1-4.1c0.6-1.4,1.9-2.8,2-2.8c0.2-0.1,0.3-0.3,0.3-0.2
+                      c0,0.2,0.2,1.2,0.4,1.8c0.1,0.7,0.9,2,0.7,3.9c-0.2,1.9-3.2,3.9-3.7,4.1c-0.1,0-0.4,0.2-0.4,0.2c-0.1,0.1,0,0.1,0.1,0.1
+                      c0.1,0,1.5-0.3,2.5-1c0.9-0.6,1.7-1.5,2-2.1c0.5-1,0.8-2.4,0.8-2.5c0.1-0.2,0.2-0.2,0.2-0.1c0,0.1,0.2,0.9,0.3,1.3
+                      c0,0.2,0.2,0.9,0.2,1.6c0,1.4-0.4,2.1-1.2,2.7c-0.5,0.4-1,0.5-1.6,0.5l-0.2,0c-0.1,0-0.2,0,0,0.1c0.1,0,0.1,0,0.2,0.1
+                      c0.5,0.2,1.4,0.2,2.1-0.2c0.3-0.2,0.7-0.5,1.2-1c0.2-0.2,0.5-0.5,0.5-0.4C73.5,25.7,73.6,26.4,73.3,26.9z" />
+                <path d="M35.8,17.1c-0.4,0-1.4,0.3-2.4,0.9c-3.4,1.8-6.8,5-8.8,7.5c-0.6,0.8-1.1,1.6-1.4,2.2c-1,2,0.4,2.4,1.4,2
+                      c1.6-0.7,3.5-1.8,4.9-3c4.1-3.5,6.5-6.7,6.9-8.2C36.7,17.8,36.7,17.1,35.8,17.1z M35.4,19.2c0,0-0.6,1.2-1.8,2.6
+                      c-1.1,1.3-2.5,2.7-2.8,3c-0.1,0-0.3,0-0.2-0.2c0.6-1.6-0.3-2.6-0.2-2.9c0.1-0.4,0.4-1,0.6-1.2c1.3-1.2,4.2-2.5,4.3-2.4
+                      c0.1,0.1,0.3,0.2,0.3,0.4C35.5,18.8,35.4,19.2,35.4,19.2z" />
+                <path d="M48.3,46.8c-0.7,0.6-11.1,10.7-11.1,10.7c0.2,0.1,0.6,0.5,0.6,0.5s9.6-9.2,10.3-9.9c0.2-0.2,0.6-0.6,0.8-0.7
+                      L48.3,46.8z" />
+                <path d="M68,34.5c0.1,0,0.3,0,0.4,0c0.1,0,0.4-0.1,0.4-0.1c0.1-0.1,0.1-0.2,0-0.2c-0.5,0-1.4-0.3-2.4-0.7
+                      c-0.6,0.2-1.6,0.4-2.8,1c-1.5,0.7-4.8,2.6-11.6,8.8l0.5,0.6c2.3-2.1,5.5-4.9,7.2-6c3-2,5.2-2.9,6.7-3.2
+                      C66.8,34.6,67.5,34.5,68,34.5z" />
+                <path d="M61.4,29.6c-1.9-1.9-2.4-3.3-2.7-4.3c0,0,0-0.1,0-0.1c0,0-0.1,0-0.1,0c0,0,0,0.1,0,0.1c-0.2,2,0,2.8-0.8,4.9
+                      C57,31.9,55.7,34.1,54,36c-1,1.2-2.7,3-4.2,4.8l1.1,1.3c0.1-0.1,0.4-0.5,0.8-0.9c5.2-5.5,9.6-8.9,11.2-10.1
+                      C62.4,30.6,61.9,30.1,61.4,29.6z" />
+                <path d="M46.1,44.9c-2.2,2.5-4.4,4.9-5,5.6c-0.5,0.6-5.3,5.7-5.3,5.7s0.1,0.2,0.3,0.4c0.2,0.2,0.4,0.4,0.4,0.4
+                      s10-10.2,10.7-11L46.1,44.9z" />
+              </g>
+            </g>
+          </svg>
+        </span>
+        <span class="logo">
+          <svg version="1.1" id="logo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" xml:space="preserve">
+            <g id="badge">
+              <g>
+                <path d="M49.5,90.4C8.9,71.7,13.8,29.7,13.8,10.1l71.8,0.1C85.6,29.8,90.1,71.8,49.5,90.4z M13.8,6.9l-3.1,3.3
+                      c0,2.3-0.1,5.3-0.1,6.7c-0.3,23,1.3,58.8,38.7,76.2c19.8-9.2,34.8-25,38.8-49.5C90.4,29.5,89,16,89,6.9L13.8,6.9z" />
+                <path d="M34.2,58.4c-2.9,3.1-5.7,6.1-6.7,7.1c-0.2,0.2-0.2,0.5-0.1,0.6c0.2,0.2,0.5,0.5,0.6,0.5
+                      c0.2,0,0.3,0.1,0.6-0.2c0.1-0.1,3.3-3.2,7-6.8c0,0-0.4-0.2-0.7-0.5C34.6,58.9,34.2,58.4,34.2,58.4z" />
+                <g>
+                  <path d="M36.1,57.6C36.8,58.3,38,59,38,59l-0.7,0.6c-0.3,0.3-1.2-0.2-2.1-1c-0.9-0.8-1.4-1.7-1.2-1.9l0.7-0.7
+                          C34.9,56,35.4,56.9,36.1,57.6z" />
+                </g>
+                <g>
+                  <g>
+                    <g>
+                      <path d="M68.9,65.5c0.6-0.6,0.6-1.1,0.6-1.1l0.7,0.3c0.2,0.2,0,1-0.6,1.6C69,66.8,68.2,67,68,66.8l-0.3-0.7
+                                  C67.6,66.1,68.3,66.1,68.9,65.5z" />
+                    </g>
+                  </g>
+                  <g>
+                    <g>
+                      <path d="M67.9,64.4c0.4-0.3,0.5-0.8,0.5-0.8l0.4,0.3c0.1,0.1,0,0.6-0.4,1.1c-0.4,0.4-1,0.6-1.2,0.4L67,64.9
+                                  C67,64.9,67.5,64.8,67.9,64.4z" />
+                    </g>
+                  </g>
+                </g>
+                <g>
+                  <path d="M65.3,27.7c1.3,1.2,2.6,2.2,3.7,2.7c0-0.1-0.1-0.1-0.1-0.2c-1-1.5-3.8-3.6-5.9-5.1
+                          C63.4,25.9,64.1,26.7,65.3,27.7z" />
+                  <path d="M69.9,31.7l-0.7,0.7c-1,0.4-3.4-1.4-5.3-3.1c-1.2-1.1-3.8-3.9-3-5l0.3-0.3c-0.2-0.1-0.4-0.3-0.6-0.3
+                          c-0.2-0.1-0.5-0.2-0.8-0.1c-0.3,0-0.5,0.2-0.6,0.4c-0.1,0.5,0.2,1.2,0.6,1.9c0.4,0.8,2,3,5.1,5.5c1.4,1.1,3.1,1.8,4.3,2.3
+                          c0.2,0.1,1,0.2,1.3-0.1c0.3-0.3,0-0.9-0.3-1.5C70.1,32,70,31.8,69.9,31.7z" />
+                </g>
+                <path d="M67.7,63.3c-1.2-1.4-10.5-12.3-11.9-14c-1.5-1.8-11-13.1-14.1-17c-3.6-4.5-4.3-10.9-4.3-11.6
+                      c0-0.3,0-0.5,0-0.8c0-0.1-0.2-0.1-0.2,0c-0.2,0.4-1.3,2.6-4.7,5.9c-2.5,2.3-5.6,4.2-7,4.7c-0.1,0-0.1,0.1-0.1,0.1
+                      c0.2,0.1,2.5,0.2,2.5,0.2c3.3,0.3,4.6,1.3,7.6,3.2c3.4,2.2,11.7,10.2,13.2,11.7c1.6,1.5,17.6,17.6,18,18c0,0,0.2,0.3,0.3,0.3
+                      c0,0,0.3,0,0.6-0.3c0.3-0.2,0.4-0.5,0.4-0.5C67.8,63.4,67.7,63.3,67.7,63.3z M66.1,62.8c0,0-8.9-9-14.5-14.8
+                      C40.6,36.5,35.5,33,32.8,31.6c-1.5-0.8-3.2-1.2-3.5-1.3c-0.2-0.1-0.3-0.3,0.2-0.7c0.6-0.5,1.6-1,2.2-1.2c0.2-0.1,1,0.2,1.8,0.5
+                      c1.5,0.6,2.8,1.4,6.1,4.7c1.1,1.1,2.4,2.4,3.8,3.9c10.1,10.7,23,25.2,23,25.2L66.1,62.8z" />
+                <path d="M74.1,23.7c-0.3,0.4-0.9,1.3-1.2,1.6c0.4-0.3,0.6-1.1,0.2-3.2c-0.3-1.5-0.5-1.9-0.7-2.4
+                      c-0.1-0.3-0.3-0.2-0.5,0c-0.2,0.2-0.6,1-0.6,1c0,0.2,0,0-0.7-2.1c-0.4-1.3-0.6-2.3-0.6-2.8c0-0.3,0-0.5,0-0.7c0-0.2-0.1-0.2-0.5,0
+                      c-0.2,0.1-2,1.4-2.8,3.3c-0.4,1.1-0.5,2-0.5,1.5c-0.1-1.1-0.1-1.1-0.2-1c-0.6,0.2-2.6,1.1-2.7,3.8c-0.5-0.1-0.9-0.1-1.1,0.1
+                      c-0.7,0.7,0.8,3.1,3.2,5.4c2.4,2.3,5,3.5,5.6,2.8c0.3-0.3,0.2-0.8-0.2-1.6c0.2,0,0.5-0.1,0.7-0.1c0,0,2.8-0.5,2.9-3.1
+                      C74.4,23.5,74.1,23.7,74.1,23.7z M73.3,26.9c-0.2,0.3-0.7,0.9-1.5,1.3c-0.9,0.4-2.1,0.5-2.7,0.3c-2.8-0.9-4.5-3.7-4.5-3.7
+                      c-2.2-3.6,0.8-5.1,1-5.2c0,0-0.3,1.2-0.1,2c0.2,0.7,0.6,1.3,0.7,1.7c0.3,0.8-0.1,1.3-0.3,1.6c-0.1,0.1,0.2,0.1,0.2,0
+                      c0,0,0.1-0.1,0.2-0.1c0.4-0.3,0.8-0.8,0.7-1.3c-0.3-1.1-1.1-1.8-0.1-4.1c0.6-1.4,1.9-2.8,2-2.8c0.2-0.1,0.3-0.3,0.3-0.2
+                      c0,0.2,0.2,1.2,0.4,1.8c0.1,0.7,0.9,2,0.7,3.9c-0.2,1.9-3.2,3.9-3.7,4.1c-0.1,0-0.4,0.2-0.4,0.2c-0.1,0.1,0,0.1,0.1,0.1
+                      c0.1,0,1.5-0.3,2.5-1c0.9-0.6,1.7-1.5,2-2.1c0.5-1,0.8-2.4,0.8-2.5c0.1-0.2,0.2-0.2,0.2-0.1c0,0.1,0.2,0.9,0.3,1.3
+                      c0,0.2,0.2,0.9,0.2,1.6c0,1.4-0.4,2.1-1.2,2.7c-0.5,0.4-1,0.5-1.6,0.5l-0.2,0c-0.1,0-0.2,0,0,0.1c0.1,0,0.1,0,0.2,0.1
+                      c0.5,0.2,1.4,0.2,2.1-0.2c0.3-0.2,0.7-0.5,1.2-1c0.2-0.2,0.5-0.5,0.5-0.4C73.5,25.7,73.6,26.4,73.3,26.9z" />
+                <path d="M35.8,17.1c-0.4,0-1.4,0.3-2.4,0.9c-3.4,1.8-6.8,5-8.8,7.5c-0.6,0.8-1.1,1.6-1.4,2.2c-1,2,0.4,2.4,1.4,2
+                      c1.6-0.7,3.5-1.8,4.9-3c4.1-3.5,6.5-6.7,6.9-8.2C36.7,17.8,36.7,17.1,35.8,17.1z M35.4,19.2c0,0-0.6,1.2-1.8,2.6
+                      c-1.1,1.3-2.5,2.7-2.8,3c-0.1,0-0.3,0-0.2-0.2c0.6-1.6-0.3-2.6-0.2-2.9c0.1-0.4,0.4-1,0.6-1.2c1.3-1.2,4.2-2.5,4.3-2.4
+                      c0.1,0.1,0.3,0.2,0.3,0.4C35.5,18.8,35.4,19.2,35.4,19.2z" />
+                <path d="M48.3,46.8c-0.7,0.6-11.1,10.7-11.1,10.7c0.2,0.1,0.6,0.5,0.6,0.5s9.6-9.2,10.3-9.9c0.2-0.2,0.6-0.6,0.8-0.7
+                      L48.3,46.8z" />
+                <path d="M68,34.5c0.1,0,0.3,0,0.4,0c0.1,0,0.4-0.1,0.4-0.1c0.1-0.1,0.1-0.2,0-0.2c-0.5,0-1.4-0.3-2.4-0.7
+                      c-0.6,0.2-1.6,0.4-2.8,1c-1.5,0.7-4.8,2.6-11.6,8.8l0.5,0.6c2.3-2.1,5.5-4.9,7.2-6c3-2,5.2-2.9,6.7-3.2
+                      C66.8,34.6,67.5,34.5,68,34.5z" />
+                <path d="M61.4,29.6c-1.9-1.9-2.4-3.3-2.7-4.3c0,0,0-0.1,0-0.1c0,0-0.1,0-0.1,0c0,0,0,0.1,0,0.1c-0.2,2,0,2.8-0.8,4.9
+                      C57,31.9,55.7,34.1,54,36c-1,1.2-2.7,3-4.2,4.8l1.1,1.3c0.1-0.1,0.4-0.5,0.8-0.9c5.2-5.5,9.6-8.9,11.2-10.1
+                      C62.4,30.6,61.9,30.1,61.4,29.6z" />
+                <path d="M46.1,44.9c-2.2,2.5-4.4,4.9-5,5.6c-0.5,0.6-5.3,5.7-5.3,5.7s0.1,0.2,0.3,0.4c0.2,0.2,0.4,0.4,0.4,0.4
+                      s10-10.2,10.7-11L46.1,44.9z" />
+              </g>
+            </g>
+          </svg>
+        </span>
+      </div>
+      <span class="branding-header-organization">Emory University</span>
+      <span class="branding-header-division">Emory Libraries</span>
+      <div class="branding-header-dropdown">
+        <select class="branding-header-dropdown-menu">
+          <option value="" selected>Select a Library</option>
+          <option value="libraries.emory.edu">Emory Libraries</option>
+          <option value="business.libraries.emory.edu">Business Library</option>
+          <option value="health.libraries.emory.edu">Health Sciences Library</option>
+          <option value="music.libraries.emory.edu">Music &amp; Media Library</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Navigation Menu (compounds-nav-menu-main) -->
+    <nav class="nav-menu-main">
+
+      <input type="checkbox" class="input -toggle" id="nav-menu--materials">
+      <input type="checkbox" class="input -toggle" id="nav-menu--tools">
+      <input type="checkbox" class="input -toggle" id="nav-menu--services">
+      <input type="checkbox" class="input -toggle" id="nav-menu--research">
+      <input type="checkbox" class="input -toggle" id="nav-menu--using-the-library">
+      <input type="checkbox" class="input -toggle" id="nav-menu--initiatives">
+      <input type="checkbox" class="input -toggle" id="nav-menu--faculty-support">
+
+      <!-- desktop -->
+      <nav class="nav-menu-main-nav -desktop">
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--materials">Materials</label>
+          <nav class="subnav-menu-main">
+
+            <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Materials</span>
+
+            <button class="subnav-button">Books</button>
+            <button class="subnav-button">Films and Videos</button>
+            <button class="subnav-button">Music and Scores</button>
+            <button class="subnav-button">Journals</button>
+            <button class="subnav-button">Databases</button>
+            <button class="subnav-button">Course Reserves</button>
+            <button class="subnav-button">eBooks and Audiobooks</button>
+            <button class="subnav-button">Research and Library Guides</button>
+            <button class="subnav-button">Theses and Dissertations</button>
+            <button class="subnav-button">Archival and Manuscripts</button>
+            <button class="subnav-button">Faculty Works</button>
+            <button class="subnav-button">Images and Maps</button>
+            <button class="subnav-button">Equipment and Gadgets</button>
+
+          </nav>
+        </div>
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--tools">Tools</label>
+          <nav class="subnav-menu-main has-resources">
+
+            <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Tools</span>
+
+            <label class="subnav-button -resource">
+              DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Emory Center for Digital Scholarship
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              Ares <span class="subnav-button-alias">(Course Reserves)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+            <label class="subnav-button -resource">
+              LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+              <input type="checkbox" class="subnav-button-options-toggle">
+              <span class="subnav-button-options">
+                <a href="" class="subnav-button-option">
+                  About
+                </a>
+                <a href="" class="subnav-button-option">
+                  Access <span class="icon">&#x2192;</span>
+                </a>
+              </span>
+            </label>
+
+          </nav>
+        </div>
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--services">Services</label>
+          <nav class="subnav-menu-main -grouped">
+
+            <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Services</span>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Around the Library</span>
+
+              <button class="subnav-button">Reserve a Study or Presentation Room</button>
+              <button class="subnav-button">Find a Quiet Study Area</button>
+              <button class="subnav-button">Find a Workstation or Application</button>
+              <button class="subnav-button">Print, Copy, and Scan</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Get Assistance</span>
+
+              <button class="subnav-button">Borrow Equipment and Gadgets</button>
+              <button class="subnav-button">Research and Writing Assistance</button>
+              <button class="subnav-button">Access Course Reserves</button>
+              <button class="subnav-button">Request or Recall Materials</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Technology Assistance</span>
+
+              <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+              <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+              <button class="subnav-button">Get Hardware or Software Support</button>
+              <button class="subnav-button">Repair Your Device or Computer</button>
+
+            </div>
+
+            <div class="subnav-button-group">
+
+              <span class="subnav-button-group-heading">Make a Request</span>
+
+              <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+              <button class="subnav-button">Request a Purchase</button>
+              <button class="subnav-button">Submit Ask eJournals</button>
+              <button class="subnav-button">Apply for an Individual Study Room</button>
+
+            </div>
+
+            <button class="subnav-button -viewall -span">View All Services</button>
+
+          </nav>
+        </div>
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--research">Research</label>
+          <nav class="subnav-menu-main -categorized">
+
+            <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Research</span>
+
+            <button class="subnav-button">Subject Librarians Directory</button>
+            <button class="subnav-button">Research Data</button>
+            <button class="subnav-button">Award and Research Programs</button>
+
+            <div class="subnav-button-category">
+
+              <span class="subnav-button-category-heading">Help With Research</span>
+
+              <button class="subnav-button">Selecting Research Topics</button>
+              <button class="subnav-button">Finding Source Materials</button>
+              <button class="subnav-button">Evaluating Sources</button>
+              <button class="subnav-button">Citing and Using Sources</button>
+
+            </div>
+
+          </nav>
+        </div>
+
+        <div class="nav-menu-main-nav-group">
+          <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
+          <nav class="subnav-menu-main -categorized">
+
+            <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
+
+            <span class="subnav-menu-main-heading">Using the Library</span>
+
+            <button class="subnav-button">Borrowing Privileges</button>
+            <button class="subnav-button">InterLibrary Lending (ILL)</button>
+            <button class="subnav-button">Library Maps and Spaces</button>
+            <button class="subnav-button">Course Reserves</button>
+            <button class="subnav-button">Guest Access</button>
+
+            <div class="subnav-button-category">
+
+              <span class="subnav-button-category-heading">Help Using the Library</span>
+
+              <button class="subnav-button">Search for Specific Items</button>
+              <button class="subnav-button">Questions About Articles</button>
+              <button class="subnav-button">Questions About Books</button>
+              <button class="subnav-button">Printing, Logging In, and Access</button>
+
+            </div>
+
+          </nav>
+        </div>
+
+      </nav>
+
+      <!-- tablet -->
+      <nav class="nav-menu-main-nav -tablet">
+
+        <label class="nav-button" for="nav-menu--materials">Materials</label>
+        <nav class="subnav-menu-main">
+
+          <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Materials</span>
+
+          <button class="subnav-button">Books</button>
+          <button class="subnav-button">Films and Videos</button>
+          <button class="subnav-button">Music and Scores</button>
+          <button class="subnav-button">Journals</button>
+          <button class="subnav-button">Databases</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">eBooks and Audiobooks</button>
+          <button class="subnav-button">Research and Library Guides</button>
+          <button class="subnav-button">Theses and Dissertations</button>
+          <button class="subnav-button">Archival and Manuscripts</button>
+          <button class="subnav-button">Faculty Works</button>
+          <button class="subnav-button">Images and Maps</button>
+          <button class="subnav-button">Equipment and Gadgets</button>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--tools">Tools</label>
+        <nav class="subnav-menu-main has-resources">
+
+          <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Tools</span>
+
+          <label class="subnav-button -resource">
+            DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Emory Center for Digital Scholarship
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            Ares <span class="subnav-button-alias">(Course Reserves)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+          <label class="subnav-button -resource">
+            LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+            <input type="checkbox" class="subnav-button-options-toggle">
+            <span class="subnav-button-options">
+              <a href="" class="subnav-button-option">
+                About
+              </a>
+              <a href="" class="subnav-button-option">
+                Access <span class="icon">&#x2192;</span>
+              </a>
+            </span>
+          </label>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--services">Services</label>
+        <nav class="subnav-menu-main -grouped">
+
+          <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Services</span>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Around the Library</span>
+
+            <button class="subnav-button">Reserve a Study or Presentation Room</button>
+            <button class="subnav-button">Find a Quiet Study Area</button>
+            <button class="subnav-button">Find a Workstation or Application</button>
+            <button class="subnav-button">Print, Copy, and Scan</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Get Assistance</span>
+
+            <button class="subnav-button">Borrow Equipment and Gadgets</button>
+            <button class="subnav-button">Research and Writing Assistance</button>
+            <button class="subnav-button">Access Course Reserves</button>
+            <button class="subnav-button">Request or Recall Materials</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Technology Assistance</span>
+
+            <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+            <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+            <button class="subnav-button">Get Hardware or Software Support</button>
+            <button class="subnav-button">Repair Your Device or Computer</button>
+
+          </div>
+
+          <div class="subnav-button-group">
+
+            <span class="subnav-button-group-heading">Make a Request</span>
+
+            <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+            <button class="subnav-button">Request a Purchase</button>
+            <button class="subnav-button">Submit Ask eJournals</button>
+            <button class="subnav-button">Apply for an Individual Study Room</button>
+
+          </div>
+
+          <button class="subnav-button -viewall -span">View All Services</button>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--research">Research</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <!-- <label class="subnav-button -back" for="nav-menu-tablet--research">Back to Main Menu</label> -->
+          <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Research</span>
+
+          <button class="subnav-button">Subject Librarians Directory</button>
+          <button class="subnav-button">Research Data</button>
+          <button class="subnav-button">Award and Research Programs</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help With Research</span>
+
+            <button class="subnav-button">Selecting Research Topics</button>
+            <button class="subnav-button">Finding Source Materials</button>
+            <button class="subnav-button">Evaluating Sources</button>
+            <button class="subnav-button">Citing and Using Sources</button>
+
+          </div>
+
+        </nav>
+
+        <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
+        <nav class="subnav-menu-main -categorized">
+
+          <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
+
+          <span class="subnav-menu-main-heading">Using the Library</span>
+
+          <button class="subnav-button">Borrowing Privileges</button>
+          <button class="subnav-button">InterLibrary Lending (ILL)</button>
+          <button class="subnav-button">Library Maps and Spaces</button>
+          <button class="subnav-button">Course Reserves</button>
+          <button class="subnav-button">Guest Access</button>
+
+          <div class="subnav-button-category">
+
+            <span class="subnav-button-category-heading">Help Using the Library</span>
+
+            <button class="subnav-button">Search for Specific Items</button>
+            <button class="subnav-button">Questions About Articles</button>
+            <button class="subnav-button">Questions About Books</button>
+            <button class="subnav-button">Printing, Logging In, and Access</button>
+
+          </div>
+
+        </nav>
+
+      </nav>
+
+      <!-- mobile -->
+      <nav class="nav-menu-main-nav -mobile">
+
+        <input type="checkbox" class="input -toggle" id="nav-menu-mobile--toggle">
+
+        <div class="nav-menu-main-nav-toggles">
+
+          <label class="nav-button -toggle -open" for="nav-menu-mobile--toggle">
+            <span class="icon" aria-hidden="true" data-icon="material-menu">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+            </span>
+            Menu
+          </label>
+
+          <label class="nav-button -toggle -close" for="nav-menu-mobile--toggle">
+            <span class="icon" aria-hidden="true" data-icon="material-menu">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" /></svg>
+            </span>
+            Close
+          </label>
+
+        </div>
+
+        <nav class="nav-menu-main-nav-menu">
+
+          <nav class="nav-menu-utility -mobile">
+
+            <div class="nav-menu-utility-right">
+
+              <label id="nav-button--events-exhibits" for="nav-menu--events-exhibits" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-event" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2zm-7 5h5v5h-5z"></path>
+                  </svg>
+                </span>
+                Events
+              </label>
+              <label id="nav-button--maps" for="nav-menu--maps" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-map" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z"></path>
+                  </svg>
+                </span>
+                Maps
+              </label>
+              <label id="nav-button--hours" for="nav-menu--hours" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-access_time" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path>
+                  </svg>
+                </span>
+                Hours
+              </label>
+              <label id="nav-button--news" for="nav-menu--news" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-newspaper" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z"></path>
+                  </svg>
+                </span>
+                News
+              </label>
+              <label id="nav-button--contact" for="nav-menu--contact" class="nav-button -flyout">
+                <span aria-hidden="true" data-icon="material-question_answer" class="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z"></path><path d="M15 4v7H5.17l-.59.59-.58.58V4h11m1-2H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm5 4h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1z"></path>
+                  </svg>
+                </span>
+                Contact
+              </label>
+
+            </div>
+
+          </nav>
+
+          <div class="nav-menu-main-nav-menu-area">
+
+            <label class="nav-button" for="nav-menu--materials">Materials</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--materials">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Materials</span>
+
+              <button class="subnav-button">Books</button>
+              <button class="subnav-button">Films and Videos</button>
+              <button class="subnav-button">Music and Scores</button>
+              <button class="subnav-button">Journals</button>
+              <button class="subnav-button">Databases</button>
+              <button class="subnav-button">Course Reserves</button>
+              <button class="subnav-button">eBooks and Audiobooks</button>
+              <button class="subnav-button">Research and Library Guides</button>
+              <button class="subnav-button">Theses and Dissertations</button>
+              <button class="subnav-button">Archival and Manuscripts</button>
+              <button class="subnav-button">Faculty Works</button>
+              <button class="subnav-button">Images and Maps</button>
+              <button class="subnav-button">Equipment and Gadgets</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--tools">Tools</label>
+            <nav class="subnav-menu-main has-resources">
+
+              <label class="subnav-button -back" for="nav-menu--tools">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Tools</span>
+
+              <label class="subnav-button -resource">
+                DiscoverE <span class="subnav-button-alias">(Books, eBooks, Journals, Videos)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                eJournals <span class="subnav-button-alias">(Academic Journals)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                ILLiad <span class="subnav-button-alias">(Inter-Library Loans)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Databases @ Emory <span class="subnav-button-alias">(Databases)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Emory Finding Aids <span class="subnav-button-alias">(Archival and Manuscripts)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Emory Center for Digital Scholarship
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                ETD <span class="subnav-button-alias">(Theses and Dissertations)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                OpenEmory <span class="subnav-button-alias">(Faculty Works)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Overdrive <span class="subnav-button-alias">(eBooks, Audiobooks)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                Ares <span class="subnav-button-alias">(Course Reserves)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+              <label class="subnav-button -resource">
+                LibGuides <span class="subnav-button-alias">(Research and Library Guides)</span>
+                <input type="checkbox" class="subnav-button-options-toggle">
+                <span class="subnav-button-options">
+                  <a href="" class="subnav-button-option">
+                    About
+                  </a>
+                  <a href="" class="subnav-button-option">
+                    Access <span class="icon">&#x2192;</span>
+                  </a>
+                </span>
+              </label>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--services">Services</label>
+            <nav class="subnav-menu-main -grouped">
+
+              <label class="subnav-button -back" for="nav-menu--services">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Services</span>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Around the Library</span>
+
+                <button class="subnav-button">Reserve a Study or Presentation Room</button>
+                <button class="subnav-button">Find a Quiet Study Area</button>
+                <button class="subnav-button">Find a Workstation or Application</button>
+                <button class="subnav-button">Print, Copy, and Scan</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Get Assistance</span>
+
+                <button class="subnav-button">Borrow Equipment and Gadgets</button>
+                <button class="subnav-button">Research and Writing Assistance</button>
+                <button class="subnav-button">Access Course Reserves</button>
+                <button class="subnav-button">Request or Recall Materials</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Technology Assistance</span>
+
+                <button class="subnav-button">Connect Off-Campus (VPNs and Proxies)</button>
+                <button class="subnav-button">Connect to the Internet (On-Campus)</button>
+                <button class="subnav-button">Get Hardware or Software Support</button>
+                <button class="subnav-button">Repair Your Device or Computer</button>
+
+              </div>
+
+              <div class="subnav-button-group">
+
+                <span class="subnav-button-group-heading">Make a Request</span>
+
+                <button class="subnav-button">Submit an ILL Request (ILLiad)</button>
+                <button class="subnav-button">Request a Purchase</button>
+                <button class="subnav-button">Submit Ask eJournals</button>
+                <button class="subnav-button">Apply for an Individual Study Room</button>
+
+              </div>
+
+              <button class="subnav-button -viewall -span">View All Services</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--research">Research</label>
+            <nav class="subnav-menu-main -categorized">
+
+              <label class="subnav-button -back" for="nav-menu--research">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Research</span>
+
+              <button class="subnav-button">Subject Librarians Directory</button>
+              <button class="subnav-button">Research Data</button>
+              <button class="subnav-button">Award and Research Programs</button>
+
+              <div class="subnav-button-category">
+
+                <span class="subnav-button-category-heading">Help With Research</span>
+
+                <button class="subnav-button">Selecting Research Topics</button>
+                <button class="subnav-button">Finding Source Materials</button>
+                <button class="subnav-button">Evaluating Sources</button>
+                <button class="subnav-button">Citing and Using Sources</button>
+
+              </div>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--using-the-library">Using the Library</label>
+            <nav class="subnav-menu-main -categorized">
+
+              <!--label class="subnav-button -back" for="nav-menu-mobile--using-the-library">Back to Main Menu</label-->
+              <label class="subnav-button -back" for="nav-menu--using-the-library">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Using the Library</span>
+
+              <button class="subnav-button">Borrowing Privileges</button>
+              <button class="subnav-button">InterLibrary Lending (ILL)</button>
+              <button class="subnav-button">Library Maps and Spaces</button>
+              <button class="subnav-button">Course Reserves</button>
+              <button class="subnav-button">Guest Access</button>
+
+              <div class="subnav-button-category">
+
+                <span class="subnav-button-category-heading">Help Using the Library</span>
+
+                <button class="subnav-button">Search for Specific Items</button>
+                <button class="subnav-button">Questions About Articles</button>
+                <button class="subnav-button">Questions About Books</button>
+                <button class="subnav-button">Printing, Logging In, and Access</button>
+
+              </div>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--initiatives">Initiatives</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--initiatives">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Initiatives</span>
+
+              <button class="subnav-button">Offices, Labs, and Departments</button>
+              <button class="subnav-button">Organizational Framework</button>
+              <button class="subnav-button">Collection Policies</button>
+              <button class="subnav-button">Digitization Program</button>
+              <button class="subnav-button">Digital Library Program</button>
+
+            </nav>
+
+            <label class="nav-button" for="nav-menu--faculty-support">Faculty Support</label>
+            <nav class="subnav-menu-main">
+
+              <label class="subnav-button -back" for="nav-menu--faculty-support">Back to Main Menu</label>
+
+              <span class="subnav-menu-main-heading">Faculty Support</span>
+
+              <button class="subnav-button">Emory Libraries Information Literacy Program</button>
+              <button class="subnav-button">Instructional Services for Faculty and TAs</button>
+              <button class="subnav-button">Creating Effective Research Assignments</button>
+              <button class="subnav-button">Media Booking Services for Instructors</button>
+              <button class="subnav-button">Request a Research Instruction Session</button>
+
+            </nav>
+
+          </div>
+
+          <a href="" class="nav-button -librarian">
+            <span aria-hidden="true" data-icon="material-help_outline" class="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"></path><path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path></svg>
+            </span>
+            Ask a librarian
+          </a>
+
+        </nav>
+
+      </nav>
+
+    </nav>
+
+  </div>
+
 </body>
 
 </html>

--- a/test/comps-organisms.scss
+++ b/test/comps-organisms.scss
@@ -37,3 +37,8 @@
 .section-deep-dive {
   @include organisms-section-deep-dive;
 }
+
+// organisms-nav-bar-main
+.nav-bar-main {
+  @include organisms-nav-bar-main;
+}


### PR DESCRIPTION
This adds styles for the `organisms-nav-bar-main` pattern. See emory-libraries/pattern-library#203. This pattern builds off of the `feature/compounds-nav-menu-main` branch (related emory-libraries/pattern-library#162) and should be merged only after #29 is closed.